### PR TITLE
feat: add location fallback and improve quote request flow

### DIFF
--- a/apps/edumatch/app/api/inquiries/[id]/quote-request/route.ts
+++ b/apps/edumatch/app/api/inquiries/[id]/quote-request/route.ts
@@ -10,6 +10,38 @@ import { prisma } from "@asafarim/db";
 export const runtime = "nodejs";
 
 /**
+ * GET /api/inquiries/[id]/quote-request
+ *
+ * Return the most recent quote request for this inquiry (student only).
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { user } = await requireStudent();
+    const { id: inquiryId } = await params;
+
+    const quoteRequest = await prisma.eduQuoteRequest.findFirst({
+      where: { inquiryId, studentId: user.id },
+      orderBy: { requestedAt: "desc" },
+      select: { id: true, status: true, expiresAt: true, requestedAt: true },
+    });
+
+    if (!quoteRequest) {
+      return NextResponse.json({ quoteRequest: null });
+    }
+
+    return NextResponse.json({ quoteRequest });
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("quote-request", error);
+    }
+    return serverError("quote-request", error);
+  }
+}
+
+/**
  * POST /api/inquiries/[id]/quote-request
  *
  * Student requests quotes for their inquiry. This:
@@ -43,8 +75,9 @@ export async function POST(
       maxDistanceKm?: number;
     };
 
-    // Resolve location: explicit coords > geocoded address > error
+    // Resolve location: explicit coords > geocoded address > student profile > error
     let location = body.studentLocation;
+
     if (!location && body.address) {
       const geocoded = await geocodeAddress(body.address);
       if (!geocoded) {
@@ -59,8 +92,19 @@ export async function POST(
       location = geocoded.location;
     }
 
+    // Fallback to student's profile location if available
     if (!location) {
-      return badRequest("Provide studentLocation {lat,lng} or address to geocode.");
+      const studentProfile = await prisma.eduStudentProfile.findUnique({
+        where: { userId: user.id },
+        select: { homeLat: true, homeLng: true },
+      });
+      if (studentProfile?.homeLat && studentProfile?.homeLng) {
+        location = { lat: studentProfile.homeLat, lng: studentProfile.homeLng };
+      }
+    }
+
+    if (!location) {
+      return badRequest("Provide studentLocation {lat,lng} or address to geocode, or set your home location in your student profile.");
     }
 
     // Create quote request

--- a/apps/edumatch/app/api/quote-requests/[id]/quotes/route.ts
+++ b/apps/edumatch/app/api/quote-requests/[id]/quotes/route.ts
@@ -6,13 +6,25 @@ import { z } from "zod";
 
 export const runtime = "nodejs";
 
+const isoOrLocalDatetime = z
+  .string()
+  .min(1)
+  .transform((val) => {
+    // Accept datetime-local format ("2026-05-03T14:30") and full ISO strings
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(val)) {
+      return new Date(val + ":00").toISOString();
+    }
+    return new Date(val).toISOString();
+  })
+  .pipe(z.string().datetime());
+
 const submitQuoteSchema = z.object({
   hourlyRateCents: z.number().int().min(100).max(100000),
   estimatedHours: z.number().min(0.5).max(100),
   availabilitySlots: z.array(
     z.object({
-      start: z.string().datetime(),
-      end: z.string().datetime(),
+      start: isoOrLocalDatetime,
+      end: isoOrLocalDatetime,
       mode: z.enum(["ONLINE", "IN_PERSON"]),
     }),
   ).min(1).max(5),

--- a/apps/edumatch/app/api/tutors/bookings/route.ts
+++ b/apps/edumatch/app/api/tutors/bookings/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { requireTutor } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { prisma } from "@asafarim/db";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/tutors/bookings
+ *
+ * List all bookings for the authenticated tutor.
+ */
+export async function GET() {
+  try {
+    const { user } = await requireTutor();
+
+    const bookings = await prisma.eduBooking.findMany({
+      where: { tutorId: user.id },
+      orderBy: { scheduledAt: "desc" },
+      include: {
+        quote: {
+          include: {
+            quoteRequest: {
+              include: {
+                inquiry: {
+                  select: { subject: true, gradeLevel: true },
+                },
+              },
+            },
+          },
+        },
+        student: {
+          select: { name: true },
+        },
+      },
+    });
+
+    const items = bookings.map((b) => ({
+      id: b.id,
+      status: b.status,
+      scheduledAt: b.scheduledAt,
+      durationMinutes: b.durationMinutes,
+      mode: b.mode,
+      totalCents: b.quote.hourlyRateCents * b.quote.estimatedHours,
+      subject: b.quote.quoteRequest.inquiry.subject,
+      gradeLevel: b.quote.quoteRequest.inquiry.gradeLevel,
+      studentName: b.student.name,
+    }));
+
+    return NextResponse.json({ items, total: items.length });
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("tutors/bookings", error);
+    }
+    return serverError("tutors/bookings", error);
+  }
+}

--- a/apps/edumatch/app/api/tutors/connect/onboard/route.ts
+++ b/apps/edumatch/app/api/tutors/connect/onboard/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireTutor } from "@/lib/server/profiles";
 import { handleEduError, badRequest, serverError } from "@/lib/server";
-import { createConnectAccount, isStripeConfigured } from "@/lib/server/stripe";
+import { createConnectAccount, isStripeConfigured, isMockMode } from "@/lib/server/stripe";
 import { prisma } from "@asafarim/db";
 
 export const runtime = "nodejs";
@@ -25,6 +25,16 @@ export async function POST(req: Request) {
 
     // If already has an account, check if onboarding is complete
     if (profile.stripeAccountId) {
+      // In mock mode, always return a redirect URL to simulate completing onboarding
+      if (isMockMode() || profile.stripeAccountId.startsWith("acct_mock_")) {
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3005";
+        const refreshUrl = `${appUrl}/tutor/connect/refresh`;
+        const returnUrl = `${appUrl}/tutor/connect/success`;
+        return NextResponse.json({
+          url: `${returnUrl}?mock=onboarding_complete&account=${profile.stripeAccountId}`,
+          accountId: profile.stripeAccountId,
+        });
+      }
       return NextResponse.json({
         accountId: profile.stripeAccountId,
         alreadyOnboarded: true,

--- a/apps/edumatch/app/api/tutors/quote-requests/route.ts
+++ b/apps/edumatch/app/api/tutors/quote-requests/route.ts
@@ -21,13 +21,14 @@ export async function GET(req: Request) {
     const lng = searchParams.get("lng");
     const maxDistanceKm = parseInt(searchParams.get("maxDistanceKm") ?? "50", 10);
 
-    // Tutor must provide location (or we could use their profile homeLocation)
+    // Resolve tutor location: query params → profile lat/lng → geocode homeAddress
     let location: { lat: number; lng: number } | null = null;
 
     if (lat && lng) {
       location = { lat: parseFloat(lat), lng: parseFloat(lng) };
+    } else if (profile.homeLat != null && profile.homeLng != null) {
+      location = { lat: profile.homeLat, lng: profile.homeLng };
     } else if (profile.homeAddress) {
-      // Try to extract from profile or geocode
       const addr = profile.homeAddress as { formatted?: string } | null;
       if (addr?.formatted) {
         const geocoded = await geocodeAddress(addr.formatted);

--- a/apps/edumatch/app/api/tutors/quotes/route.ts
+++ b/apps/edumatch/app/api/tutors/quotes/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { requireTutor } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { prisma } from "@asafarim/db";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/tutors/quotes
+ *
+ * List all quotes submitted by the authenticated tutor.
+ */
+export async function GET() {
+  try {
+    const { user } = await requireTutor();
+
+    const quotes = await prisma.eduQuote.findMany({
+      where: { tutorId: user.id },
+      orderBy: { createdAt: "desc" },
+      include: {
+        quoteRequest: {
+          include: {
+            inquiry: {
+              select: { subject: true, gradeLevel: true, description: true },
+            },
+          },
+        },
+      },
+    });
+
+    const items = quotes.map((q) => ({
+      id: q.id,
+      status: q.status,
+      hourlyRateCents: q.hourlyRateCents,
+      estimatedHours: q.estimatedHours,
+      totalCents: q.hourlyRateCents * q.estimatedHours,
+      notes: q.notes,
+      createdAt: q.createdAt,
+      subject: q.quoteRequest.inquiry.subject,
+      gradeLevel: q.quoteRequest.inquiry.gradeLevel,
+      description: q.quoteRequest.inquiry.description,
+      quoteRequestId: q.quoteRequestId,
+    }));
+
+    return NextResponse.json({ items, total: items.length });
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("tutors/quotes", error);
+    }
+    return serverError("tutors/quotes", error);
+  }
+}

--- a/apps/edumatch/app/student/inquiry/[id]/page.tsx
+++ b/apps/edumatch/app/student/inquiry/[id]/page.tsx
@@ -31,6 +31,15 @@ type Inquiry = {
   aiResponses: AiResponse[];
 };
 
+type StudentProfile = {
+  userId: string;
+  gradeLevel: string;
+  subjectsOfInterest: string[];
+  homeAddress: { formatted?: string } | null;
+  homeLat: number | null;
+  homeLng: number | null;
+};
+
 const STATUS_LABELS: Record<string, { label: string; cls: string }> = {
   NEW: { label: "New", cls: "bg-gray-100 text-gray-700" },
   AI_RESPONDED: { label: "AI Responded", cls: "bg-blue-100 text-blue-700" },
@@ -57,6 +66,9 @@ export default function InquiryDetail() {
   const [requestingQuotes, setRequestingQuotes] = useState(false);
   const [quoteRequestId, setQuoteRequestId] = useState<string | null>(null);
 
+  // Student profile state (for location)
+  const [studentProfile, setStudentProfile] = useState<StudentProfile | null>(null);
+
   useEffect(() => {
     if (!id) return;
     fetch(`/api/inquiries/${id}`)
@@ -75,6 +87,17 @@ export default function InquiryDetail() {
       .catch((e: unknown) => {
         setError(e instanceof Error ? e.message : "Failed to load");
         setLoading(false);
+      });
+
+    // Fetch student profile for location
+    fetch("/api/student/profile")
+      .then((r) => {
+        if (!r.ok) return null;
+        return r.json() as Promise<StudentProfile>;
+      })
+      .then((data) => setStudentProfile(data))
+      .catch(() => {
+        // Profile may not exist yet
       });
   }, [id]);
 
@@ -156,14 +179,52 @@ export default function InquiryDetail() {
     }
   }
 
+  async function getLocation(): Promise<{ lat: number; lng: number } | null> {
+    // 1. Use profile location if available
+    if (studentProfile?.homeLat && studentProfile?.homeLng) {
+      return { lat: studentProfile.homeLat, lng: studentProfile.homeLng };
+    }
+
+    // 2. Try browser geolocation
+    if (typeof navigator !== "undefined" && navigator.geolocation) {
+      try {
+        const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+          navigator.geolocation.getCurrentPosition(resolve, reject, {
+            enableHighAccuracy: false,
+            timeout: 10000,
+            maximumAge: 300000, // 5 minutes cache
+          });
+        });
+        return {
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        };
+      } catch {
+        // Geolocation failed or denied, continue to error
+      }
+    }
+
+    return null;
+  }
+
   async function requestTutorQuotes() {
     if (!inquiry) return;
+
+    const location = await getLocation();
+    if (!location) {
+      setError("Location required to find nearby tutors. Please set your home location in your student profile or allow browser location access.");
+      return;
+    }
+
     setRequestingQuotes(true);
     try {
       const res = await fetch(`/api/inquiries/${id}/quote-request`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ preferOnline: true }),
+        body: JSON.stringify({
+          preferOnline: true,
+          studentLocation: location,
+        }),
       });
       const data = await res.json() as { quoteRequest?: { id: string }; error?: string };
       if (!res.ok) {
@@ -314,7 +375,7 @@ export default function InquiryDetail() {
         )}
         {(inquiry.status === "TUTOR_REQUESTED" || quoteRequestId) && (
           <Link
-            href={`/student/inquiry/${id}/quotes`}
+            href={`/student/inquiry/${id}/quotes${quoteRequestId ? `?qr=${quoteRequestId}` : ""}`}
             className="rounded-lg border border-[var(--color-border-strong)] px-5 py-2.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-surface)] transition"
           >
             View Quotes

--- a/apps/edumatch/app/student/inquiry/[id]/quotes/page.tsx
+++ b/apps/edumatch/app/student/inquiry/[id]/quotes/page.tsx
@@ -34,7 +34,7 @@ export default function QuotesPage() {
   const { id: inquiryId } = useParams<{ id: string }>();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const quoteRequestId = searchParams.get("qr");
+  const qrParam = searchParams.get("qr");
 
   const [quotes, setQuotes] = useState<Quote[]>([]);
   const [loading, setLoading] = useState(true);
@@ -43,23 +43,34 @@ export default function QuotesPage() {
   const [declining, setDeclining] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!quoteRequestId) {
-      setError("No quote request found. Please go back and request tutor quotes.");
+    async function load() {
+      let quoteRequestId = qrParam;
+
+      // If no ?qr param, look it up from the inquiry
+      if (!quoteRequestId) {
+        const r = await fetch(`/api/inquiries/${inquiryId}/quote-request`);
+        const data = await r.json() as { quoteRequest?: { id: string } | null };
+        quoteRequestId = data.quoteRequest?.id ?? null;
+      }
+
+      if (!quoteRequestId) {
+        setError("No quote request found. Please go back and request tutor quotes.");
+        setLoading(false);
+        return;
+      }
+
+      const r = await fetch(`/api/quote-requests/${quoteRequestId}/quotes`);
+      const data = await r.json() as { items?: Quote[]; error?: string };
+      if (data.error) throw new Error(data.error);
+      setQuotes(data.items ?? []);
       setLoading(false);
-      return;
     }
-    fetch(`/api/quote-requests/${quoteRequestId}/quotes`)
-      .then((r) => r.json())
-      .then((data: { items?: Quote[]; error?: string }) => {
-        if (data.error) throw new Error(data.error);
-        setQuotes(data.items ?? []);
-        setLoading(false);
-      })
-      .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : "Failed to load quotes");
-        setLoading(false);
-      });
-  }, [quoteRequestId]);
+
+    load().catch((e: unknown) => {
+      setError(e instanceof Error ? e.message : "Failed to load quotes");
+      setLoading(false);
+    });
+  }, [inquiryId, qrParam]);
 
   async function accept(quoteId: string) {
     setAccepting(quoteId);

--- a/apps/edumatch/app/tutor/bookings/page.tsx
+++ b/apps/edumatch/app/tutor/bookings/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type Booking = {
+  id: string;
+  status: string;
+  scheduledAt: string | null;
+  durationMinutes: number;
+  mode: string;
+  totalCents: number;
+  subject: string;
+  gradeLevel: string;
+  studentName: string | null;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  PENDING:    "bg-amber-100 text-amber-700 border-amber-200",
+  CONFIRMED:  "bg-blue-100 text-blue-700 border-blue-200",
+  COMPLETED:  "bg-green-100 text-green-700 border-green-200",
+  CANCELLED:  "bg-red-100 text-red-600 border-red-200",
+  DISPUTED:   "bg-purple-100 text-purple-700 border-purple-200",
+};
+
+export default function TutorBookingsPage() {
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/tutors/bookings")
+      .then((r) => r.json())
+      .then((data: { items?: Booking[]; error?: string }) => {
+        if (data.error) throw new Error(data.error);
+        setBookings(data.items ?? []);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Failed to load bookings");
+        setLoading(false);
+      });
+  }, []);
+
+  const upcoming  = bookings.filter((b) => ["PENDING", "CONFIRMED"].includes(b.status));
+  const completed = bookings.filter((b) => b.status === "COMPLETED");
+  const other     = bookings.filter((b) => !["PENDING", "CONFIRMED", "COMPLETED"].includes(b.status));
+
+  if (loading) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-3 text-sm">
+        <Link href="/tutor" className="text-[var(--color-text-muted)] hover:text-[var(--color-primary)]">
+          ← Dashboard
+        </Link>
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--color-text)]">Bookings</span>
+      </div>
+
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">My Bookings</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-6">Your scheduled and past tutoring sessions.</p>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">{error}</div>
+      )}
+
+      {bookings.length === 0 ? (
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-10 text-center">
+          <p className="text-[var(--color-text-muted)] text-sm">No bookings yet.</p>
+          <p className="text-xs text-[var(--color-text-muted)] mt-1">When students accept your quotes, bookings will appear here.</p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {[
+            { title: "Upcoming", items: upcoming },
+            { title: "Completed", items: completed },
+            { title: "Other", items: other },
+          ].map(({ title, items }) =>
+            items.length === 0 ? null : (
+              <section key={title}>
+                <h2 className="mb-3 text-sm font-semibold text-[var(--color-text-muted)] uppercase tracking-wider">
+                  {title} ({items.length})
+                </h2>
+                <div className="space-y-3">
+                  {items.map((b) => (
+                    <div key={b.id} className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-5">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="flex items-center gap-2 mb-1 flex-wrap">
+                            <span className="font-semibold text-[var(--color-text)]">{b.subject}</span>
+                            <span className="rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
+                              {b.gradeLevel}
+                            </span>
+                            <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[b.status] ?? "bg-gray-100 text-gray-500 border-gray-200"}`}>
+                              {b.status}
+                            </span>
+                            <span className="rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
+                              {b.mode === "ONLINE" ? "🌐 Online" : "📍 In-Person"}
+                            </span>
+                          </div>
+                          {b.studentName && (
+                            <p className="text-sm text-[var(--color-text-muted)]">Student: {b.studentName}</p>
+                          )}
+                          {b.scheduledAt && (
+                            <p className="text-sm text-[var(--color-text-muted)]">
+                              {new Date(b.scheduledAt).toLocaleString()} · {b.durationMinutes} min
+                            </p>
+                          )}
+                        </div>
+                        <div className="text-right shrink-0">
+                          <p className="text-lg font-bold text-[var(--color-text)]">
+                            €{(b.totalCents / 100).toFixed(2)}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/edumatch/app/tutor/earnings/page.tsx
+++ b/apps/edumatch/app/tutor/earnings/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type Transaction = {
+  id: string;
+  type: "CHARGE" | "PAYOUT";
+  grossCents: number;
+  platformFeeCents: number;
+  netCents: number;
+  action: string;
+  createdAt: string;
+};
+
+type Wallet = {
+  balanceCents: number;
+  pendingCents: number;
+  lifetimeEarnedCents: number;
+};
+
+export default function TutorEarningsPage() {
+  const [wallet, setWallet] = useState<Wallet | null>(null);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/tutors/wallet")
+      .then((r) => r.json())
+      .then((data: { wallet?: Wallet; transactions?: Transaction[]; error?: string }) => {
+        if (data.error) throw new Error(data.error);
+        setWallet(data.wallet ?? null);
+        setTransactions(data.transactions ?? []);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Failed to load earnings");
+        setLoading(false);
+      });
+  }, []);
+
+  const totalEarned = transactions
+    .filter((t) => t.type === "CHARGE")
+    .reduce((sum, t) => sum + t.netCents, 0);
+
+  const totalPaidOut = transactions
+    .filter((t) => t.type === "PAYOUT")
+    .reduce((sum, t) => sum + t.netCents, 0);
+
+  if (loading) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-3 text-sm">
+        <Link href="/tutor" className="text-[var(--color-text-muted)] hover:text-[var(--color-primary)]">
+          ← Dashboard
+        </Link>
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--color-text)]">Earnings</span>
+      </div>
+
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">Earnings</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-6">Your income and payout history.</p>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">{error}</div>
+      )}
+
+      {/* Stats */}
+      <div className="mb-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: "Available Balance", value: wallet?.balanceCents ?? 0, color: "text-green-500" },
+          { label: "Pending (24h)",     value: wallet?.pendingCents ?? 0,  color: "text-amber-500" },
+          { label: "Total Earned",      value: totalEarned,                color: "text-[var(--color-text)]" },
+          { label: "Total Paid Out",    value: totalPaidOut,               color: "text-[var(--color-text)]" },
+        ].map(({ label, value, color }) => (
+          <div key={label} className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+            <p className={`text-xl font-bold ${color}`}>€{(value / 100).toFixed(2)}</p>
+            <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Transaction history */}
+      <h2 className="mb-3 text-base font-semibold text-[var(--color-text)]">Transaction History</h2>
+
+      {transactions.length === 0 ? (
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-8 text-center text-sm text-[var(--color-text-muted)]">
+          No transactions yet. Complete a booking to see your earnings here.
+        </div>
+      ) : (
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] overflow-hidden">
+          {transactions.map((t, i) => (
+            <div
+              key={t.id}
+              className={`flex items-center justify-between px-5 py-4 ${i > 0 ? "border-t border-[var(--color-border)]" : ""}`}
+            >
+              <div>
+                <p className="text-sm font-medium text-[var(--color-text)]">
+                  {t.type === "CHARGE" ? "💰 Session payment" : "🏦 Payout"}
+                </p>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  {new Date(t.createdAt).toLocaleDateString()}
+                  {t.type === "CHARGE" && t.platformFeeCents > 0 && (
+                    <span className="ml-2 text-[var(--color-text-muted)]">
+                      (fee: €{(t.platformFeeCents / 100).toFixed(2)})
+                    </span>
+                  )}
+                </p>
+              </div>
+              <p className={`text-sm font-bold ${t.type === "CHARGE" ? "text-green-500" : "text-[var(--color-text-muted)]"}`}>
+                {t.type === "CHARGE" ? "+" : "-"}€{(t.netCents / 100).toFixed(2)}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/edumatch/app/tutor/quotes/page.tsx
+++ b/apps/edumatch/app/tutor/quotes/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type Quote = {
+  id: string;
+  status: string;
+  hourlyRateCents: number;
+  estimatedHours: number;
+  totalCents: number;
+  notes: string | null;
+  createdAt: string;
+  subject: string;
+  gradeLevel: string;
+  description: string;
+  quoteRequestId: string;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  PENDING:  "bg-amber-100 text-amber-700 border-amber-200",
+  ACCEPTED: "bg-green-100 text-green-700 border-green-200",
+  REJECTED: "bg-red-100 text-red-600 border-red-200",
+  EXPIRED:  "bg-gray-100 text-gray-500 border-gray-200",
+  WITHDRAWN:"bg-gray-100 text-gray-500 border-gray-200",
+};
+
+export default function TutorQuotesPage() {
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/tutors/quotes")
+      .then((r) => r.json())
+      .then((data: { items?: Quote[]; error?: string }) => {
+        if (data.error) throw new Error(data.error);
+        setQuotes(data.items ?? []);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Failed to load quotes");
+        setLoading(false);
+      });
+  }, []);
+
+  const byStatus = (s: string) => quotes.filter((q) => q.status === s);
+  const pending  = byStatus("PENDING");
+  const accepted = byStatus("ACCEPTED");
+  const other    = quotes.filter((q) => !["PENDING", "ACCEPTED"].includes(q.status));
+
+  if (loading) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-3 text-sm">
+        <Link href="/tutor" className="text-[var(--color-text-muted)] hover:text-[var(--color-primary)]">
+          ← Dashboard
+        </Link>
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--color-text)]">My Quotes</span>
+      </div>
+
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-[var(--color-text)]">My Quotes</h1>
+          <p className="text-sm text-[var(--color-text-muted)] mt-1">
+            Quotes you've submitted to students.
+          </p>
+        </div>
+        <Link
+          href="/tutor/requests"
+          className="rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 transition"
+        >
+          Browse Requests
+        </Link>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Stats bar */}
+      <div className="mb-6 grid grid-cols-3 gap-3">
+        {[
+          { label: "Pending",  count: pending.length,  color: "text-amber-500" },
+          { label: "Accepted", count: accepted.length, color: "text-green-500" },
+          { label: "Total",    count: quotes.length,   color: "text-[var(--color-text)]" },
+        ].map(({ label, count, color }) => (
+          <div key={label} className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-4 text-center">
+            <p className={`text-2xl font-bold ${color}`}>{count}</p>
+            <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {quotes.length === 0 ? (
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-10 text-center">
+          <p className="text-[var(--color-text-muted)] text-sm">You haven't submitted any quotes yet.</p>
+          <Link
+            href="/tutor/requests"
+            className="mt-4 inline-block rounded-lg bg-[var(--color-primary)] px-5 py-2 text-sm font-medium text-white hover:opacity-90 transition"
+          >
+            Browse Open Requests
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {[
+            { title: "Pending", items: pending },
+            { title: "Accepted", items: accepted },
+            { title: "Other", items: other },
+          ].map(({ title, items }) =>
+            items.length === 0 ? null : (
+              <section key={title}>
+                <h2 className="mb-3 text-sm font-semibold text-[var(--color-text-muted)] uppercase tracking-wider">
+                  {title} ({items.length})
+                </h2>
+                <div className="space-y-3">
+                  {items.map((q) => (
+                    <div
+                      key={q.id}
+                      className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-5"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1 flex-wrap">
+                            <span className="font-semibold text-[var(--color-text)]">{q.subject}</span>
+                            <span className="rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
+                              {q.gradeLevel}
+                            </span>
+                            <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[q.status] ?? "bg-gray-100 text-gray-500 border-gray-200"}`}>
+                              {q.status}
+                            </span>
+                          </div>
+                          <p className="text-sm text-[var(--color-text-muted)] line-clamp-2">{q.description}</p>
+                        </div>
+                        <div className="text-right shrink-0">
+                          <p className="text-lg font-bold text-[var(--color-text)]">
+                            €{(q.totalCents / 100).toFixed(2)}
+                          </p>
+                          <p className="text-xs text-[var(--color-text-muted)]">
+                            €{(q.hourlyRateCents / 100).toFixed(0)}/h × {q.estimatedHours}h
+                          </p>
+                        </div>
+                      </div>
+                      {q.notes && (
+                        <p className="mt-2 text-xs text-[var(--color-text-muted)] italic border-t border-[var(--color-border)] pt-2">
+                          Note: {q.notes}
+                        </p>
+                      )}
+                      <p className="mt-2 text-xs text-[var(--color-text-muted)]">
+                        Submitted {new Date(q.createdAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/edumatch/app/tutor/requests/page.tsx
+++ b/apps/edumatch/app/tutor/requests/page.tsx
@@ -40,21 +40,42 @@ export default function TutorRequestsPage() {
   const [forms, setForms] = useState<Record<string, QuoteForm>>({});
 
   useEffect(() => {
-    fetch("/api/tutors/quote-requests")
-      .then((r) => r.json())
-      .then((data: { items?: QuoteRequest[]; error?: string }) => {
-        if (data.error) throw new Error(data.error);
-        setRequests(data.items ?? []);
-        setLoading(false);
-      })
-      .catch((e: unknown) => {
-        setError(
-          e instanceof Error && e.message.includes("lat/lng")
-            ? "Add your address in your profile to see nearby quote requests."
-            : (e instanceof Error ? e.message : "Failed to load requests"),
-        );
-        setLoading(false);
-      });
+    async function loadRequests(lat?: number, lng?: number) {
+      const url = lat != null && lng != null
+        ? `/api/tutors/quote-requests?lat=${lat}&lng=${lng}`
+        : `/api/tutors/quote-requests`;
+
+      const r = await fetch(url);
+      const data = await r.json() as { items?: QuoteRequest[]; error?: string };
+
+      if (data.error) {
+        // If no location in profile, try browser geolocation
+        if (data.error.includes("lat/lng") && lat == null) {
+          if ("geolocation" in navigator) {
+            navigator.geolocation.getCurrentPosition(
+              (pos) => loadRequests(pos.coords.latitude, pos.coords.longitude),
+              () => {
+                setError("Add your home address in your tutor profile to see nearby quote requests.");
+                setLoading(false);
+              },
+            );
+          } else {
+            setError("Add your home address in your tutor profile to see nearby quote requests.");
+            setLoading(false);
+          }
+          return;
+        }
+        throw new Error(data.error);
+      }
+
+      setRequests(data.items ?? []);
+      setLoading(false);
+    }
+
+    loadRequests().catch((e: unknown) => {
+      setError(e instanceof Error ? e.message : "Failed to load requests");
+      setLoading(false);
+    });
   }, []);
 
   function getForm(id: string): QuoteForm {
@@ -149,9 +170,18 @@ export default function TutorRequestsPage() {
       </p>
 
       {error && (
-        <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
-          {error}
-          <button onClick={() => setError(null)} className="ml-2 underline">dismiss</button>
+        <div className="mb-4 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              {error}
+              {error.includes("profile") && (
+                <Link href="/tutor/profile" className="ml-1 font-semibold underline hover:text-amber-900">
+                  Update tutor profile →
+                </Link>
+              )}
+            </div>
+            <button onClick={() => setError(null)} className="shrink-0 underline text-xs">dismiss</button>
+          </div>
         </div>
       )}
 

--- a/apps/edumatch/app/tutor/settings/page.tsx
+++ b/apps/edumatch/app/tutor/settings/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type TutorProfile = {
+  bio: string | null;
+  subjectsTaught: string[];
+  levelsTaught: string[];
+  hourlyRateCents: number;
+  onlineOnly: boolean;
+  serviceRadiusKm: number;
+  homeAddress: { formatted?: string } | null;
+};
+
+export default function TutorSettingsPage() {
+  const [profile, setProfile] = useState<TutorProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const [form, setForm] = useState({
+    onlineOnly: false,
+    serviceRadiusKm: 10,
+    hourlyRateCents: 3000,
+  });
+
+  useEffect(() => {
+    fetch("/api/tutor/profile")
+      .then((r) => r.json())
+      .then((data: { profile?: TutorProfile; error?: string }) => {
+        if (data.error) throw new Error(data.error);
+        if (data.profile) {
+          setProfile(data.profile);
+          setForm({
+            onlineOnly: data.profile.onlineOnly,
+            serviceRadiusKm: data.profile.serviceRadiusKm,
+            hourlyRateCents: data.profile.hourlyRateCents,
+          });
+        }
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Failed to load profile");
+        setLoading(false);
+      });
+  }, []);
+
+  async function saveSettings() {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const res = await fetch("/api/tutor/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...profile,
+          ...form,
+        }),
+      });
+      const data = await res.json() as { error?: string };
+      if (!res.ok) throw new Error(data.error ?? "Failed to save");
+      setSuccess(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-3 text-sm">
+        <Link href="/tutor" className="text-[var(--color-text-muted)] hover:text-[var(--color-primary)]">
+          ← Dashboard
+        </Link>
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--color-text)]">Settings</span>
+      </div>
+
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">Settings</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-6">Configure your tutoring preferences.</p>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">{error}</div>
+      )}
+      {success && (
+        <div className="mb-4 rounded-lg bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-700">
+          Settings saved successfully.
+        </div>
+      )}
+
+      <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-panel)] p-6 space-y-6">
+
+        {/* Hourly rate */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--color-text)] mb-1">Default Hourly Rate (€)</label>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            value={form.hourlyRateCents / 100}
+            onChange={(e) => setForm((f) => ({ ...f, hourlyRateCents: Math.round(parseFloat(e.target.value) * 100) }))}
+            className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+          />
+          <p className="text-xs text-[var(--color-text-muted)] mt-1">Used as the default when submitting quotes.</p>
+        </div>
+
+        {/* Online only toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-[var(--color-text)]">Online sessions only</p>
+            <p className="text-xs text-[var(--color-text-muted)] mt-0.5">Only accept online tutoring requests.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setForm((f) => ({ ...f, onlineOnly: !f.onlineOnly }))}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${form.onlineOnly ? "bg-[var(--color-primary)]" : "bg-[var(--color-border-strong)]"}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${form.onlineOnly ? "translate-x-6" : "translate-x-1"}`}
+            />
+          </button>
+        </div>
+
+        {/* Service radius */}
+        {!form.onlineOnly && (
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-text)] mb-1">
+              Service Radius: <span className="text-[var(--color-primary)]">{form.serviceRadiusKm} km</span>
+            </label>
+            <input
+              type="range"
+              min={1}
+              max={100}
+              value={form.serviceRadiusKm}
+              onChange={(e) => setForm((f) => ({ ...f, serviceRadiusKm: parseInt(e.target.value) }))}
+              className="w-full accent-[var(--color-primary)]"
+            />
+            <div className="flex justify-between text-xs text-[var(--color-text-muted)] mt-1">
+              <span>1 km</span>
+              <span>100 km</span>
+            </div>
+          </div>
+        )}
+
+        <div className="pt-2 border-t border-[var(--color-border)] flex items-center justify-between">
+          <Link
+            href="/tutor/profile"
+            className="text-sm text-[var(--color-primary)] hover:underline"
+          >
+            Edit full profile →
+          </Link>
+          <button
+            onClick={saveSettings}
+            disabled={saving}
+            className="rounded-lg bg-[var(--color-primary)] px-5 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50 transition"
+          >
+            {saving ? "Saving…" : "Save Settings"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/edumatch/lib/server/profiles.ts
+++ b/apps/edumatch/lib/server/profiles.ts
@@ -127,6 +127,9 @@ export async function requireTutor(): Promise<TutorContext> {
   }
   if (!profile) throw new EduAuthError(403, "Tutor profile required");
 
+  // Ensure role is always in sync with profile existence (handles stale sessions)
+  await assignRoleIfMissing(user.id, "edumatch_tutor");
+
   return { user, profile };
 }
 

--- a/apps/edumatch/lib/server/quotes.ts
+++ b/apps/edumatch/lib/server/quotes.ts
@@ -307,7 +307,25 @@ export async function listStudentQuoteRequests(studentId: string) {
 }
 
 /**
+ * Haversine distance in km between two lat/lng points.
+ * Used as a fallback when PostGIS is not available.
+ */
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
  * List available quote requests for a tutor (matching their expertise + location).
+ * Uses plain lat/lng columns (PostGIS not installed).
  */
 export async function listAvailableQuoteRequestsForTutor(
   tutorId: string,
@@ -320,14 +338,45 @@ export async function listAvailableQuoteRequestsForTutor(
   });
   if (!tutor) throw new QuoteError("Tutor profile not found.");
 
-  // Find open requests where:
-  // 1. Quote request is OPEN and not expired
-  // 2. Inquiry subject matches tutor's subjectsTaught (case insensitive)
-  // 3. Either online-only tutor OR within service radius
+  // Fetch all open, non-expired requests with student location
+  const openRequests = await prisma.eduQuoteRequest.findMany({
+    where: {
+      status: "OPEN",
+      expiresAt: { gt: new Date() },
+    },
+    orderBy: { requestedAt: "desc" },
+    take: 200,
+    include: {
+      inquiry: {
+        select: {
+          id: true,
+          subject: true,
+          gradeLevel: true,
+          description: true,
+          studentId: true,
+        },
+      },
+    },
+  });
 
-  const distanceMeters = maxDistanceKm * 1000;
+  // Filter by subject match
+  const subjectsLower = tutor.subjectsTaught.map((s) => s.toLowerCase());
+  const subjectMatched = tutor.subjectsTaught.length === 0
+    ? openRequests
+    : openRequests.filter((r) =>
+        subjectsLower.some((s) => r.inquiry.subject.toLowerCase().includes(s)),
+      );
 
-  const requests = await prisma.$queryRaw<Array<{
+  // Fetch student profiles for location filtering
+  const studentIds = [...new Set(subjectMatched.map((r) => r.inquiry.studentId))];
+  const studentProfiles = await prisma.eduStudentProfile.findMany({
+    where: { userId: { in: studentIds } },
+    select: { userId: true, homeLat: true, homeLng: true },
+  });
+  const profileMap = new Map(studentProfiles.map((p) => [p.userId, p]));
+
+  // Filter by distance and compute distanceKm
+  const results: Array<{
     id: string;
     inquiryId: string;
     subject: string;
@@ -335,42 +384,33 @@ export async function listAvailableQuoteRequestsForTutor(
     description: string;
     requestedAt: Date;
     expiresAt: Date;
-    distanceMeters: number;
-  }>>`
-    SELECT
-      qr.id,
-      i.id as "inquiryId",
-      i.subject,
-      i."gradeLevel",
-      i.description,
-      qr."requestedAt",
-      qr."expiresAt",
-      ST_Distance(
-        ST_SetSRID(ST_MakePoint(${location.lng}, ${location.lat}), 4326)::geography,
-        sp."homeLocation"::geography
-      ) AS "distanceMeters"
-    FROM "EduQuoteRequest" qr
-    JOIN "EduInquiry" i ON qr."inquiryId" = i.id
-    JOIN "EduStudentProfile" sp ON i."studentId" = sp."userId"
-    WHERE qr.status = 'OPEN'
-      AND qr."expiresAt" > NOW()
-      AND i.subject ILIKE ANY (
-        SELECT unnest(${tutor.subjectsTaught}::text[])
-      )
-      AND (
-        ${tutor.onlineOnly} = true
-        OR ST_DWithin(
-          sp."homeLocation"::geography,
-          ST_SetSRID(ST_MakePoint(${location.lng}, ${location.lat}), 4326)::geography,
-          ${distanceMeters}
-        )
-      )
-    ORDER BY qr."requestedAt" DESC
-    LIMIT 50
-  `;
+    distanceKm: number;
+  }> = [];
 
-  return requests.map((r) => ({
-    ...r,
-    distanceKm: Math.round((r.distanceMeters / 1000) * 10) / 10,
-  }));
+  for (const req of subjectMatched) {
+    const sp = profileMap.get(req.inquiry.studentId);
+
+    let distanceKm = 0;
+    if (sp?.homeLat != null && sp?.homeLng != null) {
+      distanceKm = Math.round(haversineKm(location.lat, location.lng, sp.homeLat, sp.homeLng) * 10) / 10;
+    }
+
+    // Skip if tutor is location-bound and student is too far
+    if (!tutor.onlineOnly && sp?.homeLat != null && distanceKm > maxDistanceKm) {
+      continue;
+    }
+
+    results.push({
+      id: req.id,
+      inquiryId: req.inquiryId,
+      subject: req.inquiry.subject,
+      gradeLevel: req.inquiry.gradeLevel,
+      description: req.inquiry.description,
+      requestedAt: req.requestedAt,
+      expiresAt: req.expiresAt,
+      distanceKm,
+    });
+  }
+
+  return results.slice(0, 50);
 }

--- a/apps/edumatch/lib/server/stripe.ts
+++ b/apps/edumatch/lib/server/stripe.ts
@@ -11,15 +11,20 @@ import Stripe from "stripe";
 
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
 const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
+const STRIPE_MOCK_MODE = process.env.STRIPE_MOCK_MODE === "true";
 
-export const stripe = STRIPE_SECRET_KEY
+export const stripe = STRIPE_SECRET_KEY && !STRIPE_MOCK_MODE
   ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2025-02-24.acacia" })
   : null;
 
 export const PLATFORM_FEE_PERCENT = 15; // 15% platform fee
 
 export function isStripeConfigured(): boolean {
-  return !!stripe;
+  return !!stripe || STRIPE_MOCK_MODE;
+}
+
+export function isMockMode(): boolean {
+  return STRIPE_MOCK_MODE;
 }
 
 export type ConnectOnboardingResult =
@@ -36,6 +41,17 @@ export async function createConnectAccount(
   refreshUrl: string,
   returnUrl: string,
 ): Promise<ConnectOnboardingResult> {
+  // Mock mode: simulate successful Connect account creation
+  if (STRIPE_MOCK_MODE) {
+    const mockAccountId = `acct_mock_${tutorId.slice(0, 8)}`;
+    console.log(`[MOCK] Creating Stripe Connect account for ${email}: ${mockAccountId}`);
+    return {
+      success: true,
+      url: `${returnUrl}?mock=onboarding_complete&account=${mockAccountId}`,
+      accountId: mockAccountId,
+    };
+  }
+
   if (!stripe) {
     return { success: false, error: "Stripe not configured. Set STRIPE_SECRET_KEY." };
   }
@@ -74,6 +90,13 @@ export async function createConnectAccount(
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // Detect specific Stripe Connect not enabled error
+    if (message.includes("signed up for Connect") || message.includes("create new accounts")) {
+      return {
+        success: false,
+        error: "Stripe Connect is not enabled on this account. Please sign up for Stripe Connect at https://dashboard.stripe.com/connect before creating tutor accounts.",
+      };
+    }
     return { success: false, error: `Stripe Connect error: ${message}` };
   }
 }
@@ -84,6 +107,11 @@ export async function createConnectAccount(
 export async function getConnectDashboardLink(
   stripeAccountId: string,
 ): Promise<string | null> {
+  // Mock mode: return a placeholder dashboard URL
+  if (STRIPE_MOCK_MODE || stripeAccountId.startsWith("acct_mock_")) {
+    return `https://dashboard.stripe.com/test/connect/accounts/${stripeAccountId}`;
+  }
+
   if (!stripe) return null;
 
   try {
@@ -108,6 +136,18 @@ export async function createBookingPaymentIntent(
   tutorStripeAccountId: string,
   description: string,
 ): Promise<PaymentIntentResult> {
+  // Mock mode: simulate successful PaymentIntent creation
+  if (STRIPE_MOCK_MODE) {
+    const mockPaymentIntentId = `pi_mock_${Date.now()}`;
+    const platformFeeCents = Math.round(totalCents * (PLATFORM_FEE_PERCENT / 100));
+    console.log(`[MOCK] Creating PaymentIntent: ${mockPaymentIntentId}, total: ${totalCents}, fee: ${platformFeeCents}`);
+    return {
+      success: true,
+      clientSecret: `${mockPaymentIntentId}_secret_mock`,
+      paymentIntentId: mockPaymentIntentId,
+    };
+  }
+
   if (!stripe) {
     return { success: false, error: "Stripe not configured." };
   }
@@ -190,6 +230,11 @@ export function constructWebhookEvent(
  * Check if a Connect account is fully onboarded and enabled.
  */
 export async function isAccountOnboarded(stripeAccountId: string): Promise<boolean> {
+  // Mock mode: always consider mock accounts as onboarded
+  if (STRIPE_MOCK_MODE || stripeAccountId.startsWith("acct_mock_")) {
+    return true;
+  }
+
   if (!stripe) return false;
 
   try {
@@ -208,6 +253,13 @@ export async function createPayout(
   stripeAccountId: string,
   amountCents: number,
 ): Promise<{ success: boolean; payoutId?: string; error?: string }> {
+  // Mock mode: simulate successful payout
+  if (STRIPE_MOCK_MODE) {
+    const mockPayoutId = `po_mock_${Date.now()}`;
+    console.log(`[MOCK] Creating payout: ${mockPayoutId}, amount: ${amountCents}, account: ${stripeAccountId}`);
+    return { success: true, payoutId: mockPayoutId };
+  }
+
   if (!stripe) {
     return { success: false, error: "Stripe not configured." };
   }

--- a/apps/edumatch/lib/server/tutor-matching.ts
+++ b/apps/edumatch/lib/server/tutor-matching.ts
@@ -1,10 +1,13 @@
 /**
- * Phase 3 — Tutor matching with PostGIS spatial queries.
+ * Phase 3 — Tutor matching.
  *
  * Core capabilities:
- * - Find tutors within radius using `ST_DWithin` on `homeLocation`
+ * - Find tutors within radius using Haversine on homeLat/homeLng columns
  * - Match by subject expertise, grade level, and availability
  * - Score and rank tutors by composite algorithm
+ *
+ * Note: PostGIS is not yet installed; uses plain lat/lng Float columns.
+ * TODO: Migrate to ST_DWithin once PostGIS is enabled.
  */
 
 import { prisma } from "@asafarim/db";
@@ -45,78 +48,82 @@ export type ScoredTutor = {
 };
 
 /**
- * Find tutors within the specified radius using PostGIS ST_DWithin.
- * Requires `homeLocation` to be populated (geography(Point, 4326)).
- *
- * Note: The first migration must `CREATE EXTENSION IF NOT EXISTS postgis;`
+ * Haversine distance in km between two lat/lng points.
+ */
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Find tutors within the specified radius using Haversine on homeLat/homeLng.
+ * (PostGIS is not yet installed; uses plain Float columns.)
  */
 export async function findNearbyTutors(
   input: TutorMatchInput,
 ): Promise<ScoredTutor[]> {
   const { studentLocation, maxDistanceKm = 50, limit = 20 } = input;
 
-  // PostGIS ST_DWithin uses meters; convert km to meters
-  const distanceMeters = maxDistanceKm * 1000;
+  const tutors = await prisma.eduTutorProfile.findMany({
+    where: {
+      OR: [
+        { onlineOnly: true },
+        { homeLat: { not: null }, homeLng: { not: null } },
+      ],
+    },
+    select: {
+      userId: true,
+      bio: true,
+      subjectsTaught: true,
+      levelsTaught: true,
+      hourlyRateCents: true,
+      onlineOnly: true,
+      serviceRadiusKm: true,
+      ratingAvg: true,
+      ratingCount: true,
+      verifiedAt: true,
+      homeLat: true,
+      homeLng: true,
+    },
+  });
 
-  // Raw query with PostGIS geography operators
-  // Uses index on homeLocation if available
-  const results = await prisma.$queryRaw<Array<{
-    userId: string;
-    bio: string | null;
-    subjectsTaught: string[];
-    levelsTaught: string[];
-    hourlyRateCents: number;
-    onlineOnly: boolean;
-    serviceRadiusKm: number;
-    ratingAvg: number;
-    ratingCount: number;
-    verifiedAt: Date | null;
-    distanceMeters: number;
-  }>>`
-    SELECT
-      tp."userId",
-      tp.bio,
-      tp."subjectsTaught",
-      tp."levelsTaught",
-      tp."hourlyRateCents",
-      tp."onlineOnly",
-      tp."serviceRadiusKm",
-      tp."ratingAvg",
-      tp."ratingCount",
-      tp."verifiedAt",
-      ST_Distance(
-        tp."homeLocation"::geography,
-        ST_SetSRID(ST_MakePoint(${studentLocation.lng}, ${studentLocation.lat}), 4326)::geography
-      ) AS "distanceMeters"
-    FROM "EduTutorProfile" tp
-    WHERE tp."homeLocation" IS NOT NULL
-      AND ST_DWithin(
-        tp."homeLocation"::geography,
-        ST_SetSRID(ST_MakePoint(${studentLocation.lng}, ${studentLocation.lat}), 4326)::geography,
-        ${distanceMeters}
-      )
-      AND tp."serviceRadiusKm" >= ${maxDistanceKm}
-    ORDER BY "distanceMeters" ASC
-    LIMIT ${limit}
-  `;
+  const nearby: ScoredTutor[] = [];
+  for (const t of tutors) {
+    let distanceKm = 0;
+    if (t.homeLat != null && t.homeLng != null) {
+      distanceKm = Math.round(
+        haversineKm(studentLocation.lat, studentLocation.lng, t.homeLat, t.homeLng) * 10,
+      ) / 10;
+      if (!t.onlineOnly && distanceKm > maxDistanceKm) continue;
+    }
+    nearby.push({
+      userId: t.userId,
+      bio: t.bio,
+      subjectsTaught: t.subjectsTaught,
+      levelsTaught: t.levelsTaught,
+      hourlyRateCents: t.hourlyRateCents,
+      onlineOnly: t.onlineOnly,
+      serviceRadiusKm: t.serviceRadiusKm,
+      ratingAvg: t.ratingAvg,
+      ratingCount: t.ratingCount,
+      verifiedAt: t.verifiedAt,
+      distanceKm,
+      subjectMatch: false,
+      levelMatch: false,
+      availabilityScore: 0,
+      compositeScore: 0,
+    });
+  }
 
-  return results.map((r) => ({
-    userId: r.userId,
-    bio: r.bio,
-    subjectsTaught: r.subjectsTaught,
-    levelsTaught: r.levelsTaught,
-    hourlyRateCents: r.hourlyRateCents,
-    onlineOnly: r.onlineOnly,
-    serviceRadiusKm: r.serviceRadiusKm,
-    ratingAvg: r.ratingAvg,
-    ratingCount: r.ratingCount,
-    verifiedAt: r.verifiedAt,
-    distanceKm: Math.round((r.distanceMeters / 1000) * 10) / 10,
-    subjectMatch: false, // computed below
-    levelMatch: false,
-    availabilityScore: 0,
-    compositeScore: 0,
-  }));
+  return nearby.sort((a, b) => a.distanceKm - b.distanceKm).slice(0, limit);
 }
 
 /**
@@ -197,25 +204,21 @@ export async function findBestTutors(
 
 /**
  * Check if a tutor can service a specific location.
- * Verifies the tutor's service radius covers the point.
+ * Uses Haversine with homeLat/homeLng (PostGIS not available).
  */
 export async function canTutorServiceLocation(
   tutorId: string,
   location: GeoPoint,
 ): Promise<boolean> {
-  const result = await prisma.$queryRaw<{ withinRadius: boolean }[]>`
-    SELECT ST_DWithin(
-      tp."homeLocation"::geography,
-      ST_SetSRID(ST_MakePoint(${location.lng}, ${location.lat}), 4326)::geography,
-      tp."serviceRadiusKm" * 1000
-    ) AS "withinRadius"
-    FROM "EduTutorProfile" tp
-    WHERE tp."userId" = ${tutorId}
-      AND tp."homeLocation" IS NOT NULL
-    LIMIT 1
-  `;
-
-  return result[0]?.withinRadius ?? false;
+  const tutor = await prisma.eduTutorProfile.findUnique({
+    where: { userId: tutorId },
+    select: { onlineOnly: true, serviceRadiusKm: true, homeLat: true, homeLng: true },
+  });
+  if (!tutor) return false;
+  if (tutor.onlineOnly) return true;
+  if (tutor.homeLat == null || tutor.homeLng == null) return false;
+  const distanceKm = haversineKm(location.lat, location.lng, tutor.homeLat, tutor.homeLng);
+  return distanceKm <= tutor.serviceRadiusKm;
 }
 
 /**
@@ -226,9 +229,8 @@ export async function updateTutorLocation(
   tutorId: string,
   location: GeoPoint,
 ): Promise<void> {
-  await prisma.$executeRaw`
-    UPDATE "EduTutorProfile"
-    SET "homeLocation" = ST_SetSRID(ST_MakePoint(${location.lng}, ${location.lat}), 4326)
-    WHERE "userId" = ${tutorId}
-  `;
+  await prisma.eduTutorProfile.update({
+    where: { userId: tutorId },
+    data: { homeLat: location.lat, homeLng: location.lng },
+  });
 }

--- a/docs/issues/010-tutor-onboarding-postgis-fixes.md
+++ b/docs/issues/010-tutor-onboarding-postgis-fixes.md
@@ -1,0 +1,149 @@
+# Fix Tutor Onboarding, PostGIS Dependencies, and Missing Pages
+
+**Date:** 2026-05-03  
+**Status:** Completed
+
+## Summary
+Fixed multiple issues in the tutor onboarding flow, resolved PostGIS dependencies by migrating to Haversine distance calculations, and created missing tutor pages.
+
+## Issues Fixed
+
+### 1. Tutor Onboarding - "Complete Verification" Button Not Working
+**Problem:** Clicking "Complete Verification" on `/tutor/connect/onboard` did nothing, even with `STRIPE_MOCK_MODE=true`.
+
+**Root Cause:** When a tutor already had a `stripeAccountId`, the API returned `alreadyOnboarded: true` without a redirect URL. The frontend had no path to proceed.
+
+**Solution:**
+- Modified `app/api/tutors/connect/onboard/route.ts` to return a redirect URL in mock mode even when account exists
+- Redirects to `/tutor/connect/success?mock=onboarding_complete&account=...`
+
+**Files Changed:**
+- `apps/edumatch/app/api/tutors/connect/onboard/route.ts`
+
+---
+
+### 2. Tutor Navbar Items Not Showing
+**Problem:** Seeded tutor navbar items didn't appear for authenticated tutors.
+
+**Root Cause:** The `edumatch_tutor` role is only assigned when `upsertTutorProfile` is called. If a user had the role in DB but session JWT was stale, the role wouldn't appear in `user.roles`.
+
+**Solution:**
+- Added auto-assign role check in `requireTutor()` to ensure role is always in sync with profile existence
+- Users can click "Refresh session" in user menu to update their JWT with current roles
+
+**Files Changed:**
+- `apps/edumatch/lib/server/profiles.ts`
+
+---
+
+### 3. Tutor Requests Page - Location Error (PostGIS Not Installed)
+**Problem:** `/tutor/requests` returned 500 error: `ERROR: type "geography" does not exist`
+
+**Root Cause:** Code used PostGIS `ST_DWithin`, `ST_Distance`, `ST_MakePoint` functions on a `homeLocation` geography column that doesn't exist. The schema uses plain `homeLat`/`homeLng` Float columns (PostGIS not installed per schema comment).
+
+**Solution:** 
+- Replaced raw PostGIS SQL with Prisma queries + JavaScript Haversine distance calculation
+- Updated `listAvailableQuoteRequestsForTutor` to use `homeLat`/`homeLng` columns
+- Added `haversineKm()` helper function
+
+**Files Changed:**
+- `apps/edumatch/lib/server/quotes.ts`
+
+---
+
+### 4. Tutor Matching - PostGIS Dependencies
+**Problem:** `tutor-matching.ts` had the same PostGIS dependencies and would crash on any tutor-matching API call.
+
+**Root Cause:** Same as #3 — used PostGIS functions on non-existent `homeLocation` column.
+
+**Solution:**
+- Replaced all PostGIS queries with Haversine-based approach
+- Updated `findNearbyTutors`, `canTutorServiceLocation`, `updateTutorLocation`
+- Added `haversineKm()` helper
+
+**Files Changed:**
+- `apps/edumatch/lib/server/tutor-matching.ts`
+
+---
+
+### 5. Quote Submission - Invalid Datetime Validation
+**Problem:** Submitting a quote returned `availabilitySlots.0.start: Invalid datetime; availabilitySlots.0.end: Invalid datetime`
+
+**Root Cause:** `z.string().datetime()` requires full ISO 8601 with seconds and timezone (e.g., `2026-05-03T14:30:00.000Z`), but `datetime-local` input produces `2026-05-03T14:30` without seconds or timezone.
+
+**Solution:**
+- Added `isoOrLocalDatetime` Zod transformer that accepts both formats
+- Normalizes datetime-local strings to full ISO strings before validation
+
+**Files Changed:**
+- `apps/edumatch/app/api/quote-requests/[id]/quotes/route.ts`
+
+---
+
+### 6. Missing Tutor Pages (404 Errors)
+**Problem:** Navbar links to `/tutor/quotes`, `/tutor/bookings`, `/tutor/earnings`, `/tutor/settings` returned 404.
+
+**Solution:** Created all missing pages and their API routes:
+- `/tutor/quotes` — lists submitted quotes with status grouping
+- `/tutor/bookings` — lists upcoming and completed sessions
+- `/tutor/earnings` — balance, payout history, transactions
+- `/tutor/settings` — hourly rate, online-only toggle, service radius
+
+**Files Created:**
+- `apps/edumatch/app/tutor/quotes/page.tsx`
+- `apps/edumatch/app/tutor/bookings/page.tsx`
+- `apps/edumatch/app/tutor/earnings/page.tsx`
+- `apps/edumatch/app/tutor/settings/page.tsx`
+- `apps/edumatch/app/api/tutors/quotes/route.ts`
+- `apps/edumatch/app/api/tutors/bookings/route.ts`
+
+---
+
+### 7. Student Quotes Page - "No quote request found"
+**Problem:** `/student/inquiry/[id]/quotes` showed "No quote request found" even after requesting quotes.
+
+**Root Cause:** The "View Quotes" link didn't include the `?qr=` query param, and the page couldn't auto-resolve the quote request ID.
+
+**Solution:**
+- Added GET handler to `/api/inquiries/[id]/quote-request` to return the most recent quote request
+- Updated "View Quotes" link to include `?qr=${quoteRequestId}` when available
+- Modified quotes page to auto-resolve quoteRequestId via API when `?qr` param is missing
+
+**Files Changed:**
+- `apps/edumatch/app/api/inquiries/[id]/quote-request/route.ts` (added GET)
+- `apps/edumatch/app/student/inquiry/[id]/page.tsx` (link fix)
+- `apps/edumatch/app/student/inquiry/[id]/quotes/page.tsx` (auto-resolve)
+
+---
+
+## Technical Debt / TODOs
+
+1. **PostGIS Migration:** When PostGIS is installed on the database, consider migrating back to `ST_DWithin` for better performance on large datasets. The Haversine approach loads all tutors into memory and filters in JS, which won't scale to thousands of tutors.
+
+2. **Tutor Profile Location Update:** The `updateTutorLocation` function now writes to `homeLat`/`homeLng` instead of `homeLocation`. Ensure any existing geocoding flows are updated to use these columns.
+
+3. **Session Refresh UX:** Consider making the "Refresh session" action more discoverable or auto-refreshing when role mismatch is detected.
+
+---
+
+## Testing Checklist
+
+- [x] Tutor onboarding works with `STRIPE_MOCK_MODE=true`
+- [x] Tutor navbar items appear after session refresh
+- [x] `/tutor/requests` loads with browser geolocation fallback
+- [x] Quote submission accepts datetime-local format
+- [x] All tutor pages load without 404
+- [x] Student quotes page loads and displays quotes
+- [x] "View Quotes" link includes `?qr=` param
+
+---
+
+## Related Schema Notes
+
+Per `packages/db/prisma/schema.prisma`:
+```prisma
+// Geo fields temporarily use simple lat/lng Float columns (PostGIS not installed).
+// TODO: Revert to PostGIS geography once PostGIS is available on the database.
+```
+
+The changes in this session align with the schema's current limitations. Once PostGIS is enabled, a migration back to spatial queries should be considered.

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -248,7 +248,13 @@ const defaultNavItems = [
   // EduMatch nav items - Header
   { label: "Home", href: "/", position: 0, group: "main", visibility: "public", appScope: ["edumatch"], placement: "header", icon: "home" },
   { label: "Student", href: "/student", position: 1, group: "main", visibility: "role", requiredRole: "edumatch_student", appScope: ["edumatch"], placement: "header", icon: "education" },
+  
+  // Tutor header navbar items - Quick access to key features
   { label: "Tutor", href: "/tutor", position: 1, group: "main", visibility: "role", requiredRole: "edumatch_tutor", appScope: ["edumatch"], placement: "header", icon: "users" },
+  { label: "Quote Requests", href: "/tutor/requests", position: 2, group: "main", visibility: "role", requiredRole: "edumatch_tutor", appScope: ["edumatch"], placement: "header", icon: "chat" },
+  { label: "My Quotes", href: "/tutor/quotes", position: 3, group: "main", visibility: "role", requiredRole: "edumatch_tutor", appScope: ["edumatch"], placement: "header", icon: "list" },
+  { label: "Bookings", href: "/tutor/bookings", position: 4, group: "main", visibility: "role", requiredRole: "edumatch_tutor", appScope: ["edumatch"], placement: "header", icon: "layers" },
+  { label: "Earnings", href: "/tutor/earnings", position: 5, group: "main", visibility: "role", requiredRole: "edumatch_tutor", appScope: ["edumatch"], placement: "header", icon: "analytics" },
 
   // EduMatch nav items - Student Sidebar
   { label: "Dashboard", href: "/student", position: 0, group: "main", visibility: "role", requiredRole: "edumatch_student", appScope: ["edumatch"], placement: "sidebar", icon: "overview" },


### PR DESCRIPTION
- Add GET endpoint for quote requests to fetch most recent request
- Implement location fallback chain: explicit coords → geocoded address → student profile → error
- Add datetime-local format support for availability slots in quote submission
- Return mock onboarding URL in Stripe Connect when in mock mode
- Use tutor profile location (lat/lng or geocoded homeAddress) when query params not provided
- Fetch student profile location

Refs #24