### PR TITLE
feat: add public homepage to ops-hub and improve cross-app auth flow

### DIFF
--- a/apps/ops-hub/README.md
+++ b/apps/ops-hub/README.md
@@ -4,6 +4,8 @@ Internal operator console for managing a SaaS business across tenants, users,
 subscriptions, feature access, lifecycle state, metrics, automations, and audit
 history.
 
+Full roadmap: [docs/ops-hub-project-plan.md](../../docs/ops-hub-project-plan.md)
+
 ## Status
 
 Current state: operator MVP.

--- a/apps/ops-hub/app/PublicHomepage.tsx
+++ b/apps/ops-hub/app/PublicHomepage.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Activity,
+  Shield,
+  Users,
+  CreditCard,
+  Flag,
+  History,
+  Zap,
+  ArrowRight,
+  CheckCircle,
+  Lock,
+  Server,
+  BarChart3,
+} from "lucide-react";
+
+const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || "https://portal-qa.asafarim.com";
+const currentAppUrl = process.env.NEXT_PUBLIC_OPS_HUB_URL || "http://localhost:3003";
+
+const features = [
+  {
+    icon: Activity,
+    title: "Tenant Monitoring",
+    description: "Track tenant health, status, and lifecycle from trial to churn. Spot at-risk accounts before they leave.",
+    accent: "from-indigo-500 to-cyan-400",
+  },
+  {
+    icon: CreditCard,
+    title: "Billing Visibility",
+    description: "Monitor MRR, subscriptions, invoices, and payment status. Connect to Stripe for real-time revenue data.",
+    accent: "from-cyan-400 to-emerald-400",
+  },
+  {
+    icon: Users,
+    title: "User Lifecycle",
+    description: "Track user onboarding, activity, and churn. Understand how customers move through your product.",
+    accent: "from-emerald-400 to-amber-400",
+  },
+  {
+    icon: Flag,
+    title: "Feature Flags",
+    description: "Control rollouts, kill switches, and tenant-specific overrides. Manage risk during deployments.",
+    accent: "from-amber-400 to-rose-400",
+  },
+  {
+    icon: Zap,
+    title: "Automation Monitoring",
+    description: "Watch automation health, track runs, and review failures. Ensure operational jobs run smoothly.",
+    accent: "from-rose-400 to-violet-400",
+  },
+  {
+    icon: History,
+    title: "Audit History",
+    description: "Immutable log of operator actions. Know who changed what, when, and why across all operations.",
+    accent: "from-violet-400 to-indigo-500",
+  },
+];
+
+const capabilities = [
+  { title: "Churn Risk Detection", description: "AI-assisted risk signals" },
+  { title: "Revenue Analytics", description: "MRR, ARR, plan mix" },
+  { title: "Subscription Health", description: "Status and renewal tracking" },
+  { title: "Invoice Management", description: "Open, paid, and past-due" },
+  { title: "Usage Metrics", description: "Weekly and monthly rollups" },
+  { title: "System Health", description: "Service status and alerts" },
+];
+
+export function PublicHomepage() {
+  const [hoveredFeature, setHoveredFeature] = useState<number | null>(null);
+
+  const signInUrl = `${portalUrl}/sign-in?callbackUrl=${encodeURIComponent(currentAppUrl + "/")}`;
+  const registerUrl = `${portalUrl}/sign-up?callbackUrl=${encodeURIComponent(currentAppUrl + "/")}`;
+
+  return (
+    <div className="relative min-h-screen overflow-x-hidden bg-[var(--color-surface)] text-[var(--color-text)]">
+      {/* Background gradients */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_0%,rgba(99,102,241,0.15),transparent_40%),radial-gradient(circle_at_85%_10%,rgba(34,211,238,0.12),transparent_38%),radial-gradient(circle_at_50%_85%,rgba(168,85,247,0.10),transparent_40%)]"
+      />
+
+      {/* Header */}
+      <header className="sticky top-0 z-50 border-b border-[var(--color-border)] bg-[var(--color-surface)]/80 backdrop-blur">
+        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
+          <div className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-500 to-cyan-400">
+              <Server className="h-4 w-4 text-white" />
+            </div>
+            <span className="font-semibold">Ops Hub</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <a
+              href={signInUrl}
+              className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)]"
+            >
+              Sign In
+            </a>
+            <a
+              href={registerUrl}
+              className="rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white hover:brightness-110"
+            >
+              Get Access
+            </a>
+          </div>
+        </div>
+      </header>
+
+      {/* Hero Section */}
+      <section className="mx-auto w-full max-w-7xl px-6 pt-16 sm:pt-24">
+        <div className="flex flex-col items-center text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-glass)] px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--color-text-secondary)]">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
+            SaaS Operations Console
+          </span>
+
+          <h1 className="mt-6 max-w-3xl text-4xl font-bold tracking-tight sm:text-5xl">
+            The control room for your{" "}
+            <span className="bg-gradient-to-r from-indigo-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent">
+              SaaS business
+            </span>
+          </h1>
+
+          <p className="mt-4 max-w-2xl text-base leading-relaxed text-[var(--color-text-secondary)] sm:text-lg">
+            Monitor tenants, track revenue, manage rollouts, and run operations from one console. 
+            Built for operators who need answers fast.
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <a
+              href={signInUrl}
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/25 transition hover:brightness-110"
+            >
+              <Lock className="h-4 w-4" />
+              Sign In to Console
+              <ArrowRight className="h-4 w-4" />
+            </a>
+            <a
+              href={portalUrl}
+              className="inline-flex items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-glass)] px-6 py-3 text-sm font-medium text-[var(--color-text)] transition hover:border-[var(--color-primary)]"
+            >
+              Return to Portal
+            </a>
+          </div>
+
+          <div className="mt-4 flex items-center gap-2 text-xs text-[var(--color-text-subtle)]">
+            <Shield className="h-3 w-3" />
+            <span>Protected operator access required</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Features Grid */}
+      <section className="mx-auto mt-20 w-full max-w-7xl px-6">
+        <h2 className="mb-8 text-center text-2xl font-semibold tracking-tight">
+          Everything an operator needs
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature, index) => (
+            <article
+              key={feature.title}
+              className="group relative overflow-hidden rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-6 transition hover:-translate-y-0.5 hover:border-[var(--color-primary)]"
+              onMouseEnter={() => setHoveredFeature(index)}
+              onMouseLeave={() => setHoveredFeature(null)}
+            >
+              <div
+                className={`absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r ${feature.accent} opacity-80`}
+              />
+              <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--color-surface)]">
+                <feature.icon className="h-5 w-5 text-[var(--color-primary)]" />
+              </div>
+              <h3 className="text-base font-semibold tracking-tight">{feature.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+                {feature.description}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* Capabilities */}
+      <section className="mx-auto mt-16 w-full max-w-7xl px-6">
+        <h2 className="mb-8 text-center text-2xl font-semibold tracking-tight">
+          Operational capabilities
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {capabilities.map((cap) => (
+            <div
+              key={cap.title}
+              className="flex items-start gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-4 transition hover:border-[var(--color-primary)]"
+            >
+              <CheckCircle className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
+              <div>
+                <h3 className="text-sm font-semibold">{cap.title}</h3>
+                <p className="text-xs text-[var(--color-text-secondary)]">{cap.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Why Protected Section */}
+      <section className="mx-auto mt-16 w-full max-w-7xl px-6">
+        <div className="rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-8 sm:p-12">
+          <div className="mx-auto max-w-3xl text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-rose-500/10">
+              <Lock className="h-6 w-6 text-rose-400" />
+            </div>
+            <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+              Why is sign-in required?
+            </h2>
+            <p className="mt-3 text-[var(--color-text-secondary)]">
+              Ops Hub contains sensitive business, customer, billing, and operational data. 
+              Access is restricted to authorized operators with proper permissions.
+            </p>
+
+            <div className="mt-8 grid gap-4 text-left sm:grid-cols-2">
+              <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+                <h3 className="text-sm font-semibold">Protected Data</h3>
+                <ul className="mt-2 space-y-1 text-xs text-[var(--color-text-secondary)]">
+                  <li>• Tenant business information</li>
+                  <li>• Revenue and billing data</li>
+                  <li>• User and customer records</li>
+                  <li>• Feature flag configurations</li>
+                </ul>
+              </div>
+              <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+                <h3 className="text-sm font-semibold">Required Roles</h3>
+                <ul className="mt-2 space-y-1 text-xs text-[var(--color-text-secondary)]">
+                  <li>• ops_viewer — Read-only access</li>
+                  <li>• ops_admin — Full console access</li>
+                  <li>• superadmin — All permissions</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="mt-8">
+              <a
+                href={registerUrl}
+                className="inline-flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/25 transition hover:brightness-110"
+              >
+                Request Access
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="mx-auto mt-16 w-full max-w-7xl px-6 pb-16">
+        <div className="flex flex-col items-center justify-between gap-4 border-t border-[var(--color-border)] pt-8 sm:flex-row">
+          <div className="flex items-center gap-2">
+            <Server className="h-4 w-4 text-[var(--color-text-secondary)]" />
+            <span className="text-sm text-[var(--color-text-secondary)]">
+              Part of the ASafariM Portal ecosystem
+            </span>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-[var(--color-text-secondary)]">
+            <a href={portalUrl} className="hover:text-[var(--color-text)]">
+              Portal
+            </a>
+            <span>·</span>
+            <span className="flex items-center gap-1">
+              <BarChart3 className="h-3 w-3" />
+              Operator Console
+            </span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/ops-hub/app/layout.tsx
+++ b/apps/ops-hub/app/layout.tsx
@@ -50,6 +50,25 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const cookieTheme = readThemeFromCookie(cookieStore.toString());
   const initialTheme = cookieTheme ?? "dark";
 
+  // Unauthenticated users see public homepage (no Shell, no rbac check)
+  if (!session?.user) {
+    return (
+      <html lang="en" suppressHydrationWarning data-theme={initialTheme}>
+        <head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: themeInitScript,
+            }}
+          />
+        </head>
+        <body>
+          <SessionProvider>{children}</SessionProvider>
+        </body>
+      </html>
+    );
+  }
+
+  // Authenticated users: check ops permissions
   let forbidden: string | null = null;
   try {
     await requireOps("read");
@@ -59,9 +78,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   }
 
   const user = {
-    name: session?.user?.name ?? null,
-    email: session?.user?.email ?? "",
-    roles: session?.user?.roles ?? [],
+    name: session.user.name ?? null,
+    email: session.user.email ?? "",
+    roles: session.user.roles ?? [],
   };
 
   return (

--- a/apps/ops-hub/app/page.tsx
+++ b/apps/ops-hub/app/page.tsx
@@ -1,5 +1,15 @@
+import { auth } from "@asafarim/auth";
 import { redirect } from "next/navigation";
+import { PublicHomepage } from "./PublicHomepage";
 
-export default function RootPage() {
+export default async function RootPage() {
+  const session = await auth();
+
+  // Unauthenticated users see the public homepage
+  if (!session?.user) {
+    return <PublicHomepage />;
+  }
+
+  // Authenticated users redirect to the overview console
   redirect("/overview");
 }

--- a/apps/ops-hub/middleware.ts
+++ b/apps/ops-hub/middleware.ts
@@ -6,7 +6,7 @@ const portalUrl = process.env.PORTAL_URL || "https://portal-qa.asafarim.com";
 // Middleware simply ensures the user is signed in; role gating is done server-side for
 // clear 403 pages instead of silent redirects.
 export const middleware = createAuthMiddleware({
-  publicRoutes: ["/api/health"],
+  publicRoutes: ["/api/health", "/"],
   signInUrl: `${portalUrl}/sign-in`,
 });
 

--- a/apps/ops-hub/package.json
+++ b/apps/ops-hub/package.json
@@ -13,6 +13,7 @@
     "@asafarim/auth": "workspace:*",
     "@asafarim/db": "workspace:*",
     "@asafarim/ui": "workspace:*",
+    "lucide-react": "^0.462.0",
     "next": "^15.3.0",
     "next-auth": "^5.0.0-beta.28",
     "react": "^19.0.0",

--- a/apps/portal/app/(auth)/sign-in/page.tsx
+++ b/apps/portal/app/(auth)/sign-in/page.tsx
@@ -18,6 +18,8 @@ function isTrustedCallbackOrigin(origin: string): boolean {
   const allowList = [
     process.env.NEXT_PUBLIC_CONTENT_GENERATOR_URL,
     process.env.NEXT_PUBLIC_PORTAL_URL,
+    process.env.NEXT_PUBLIC_OPS_HUB_URL,
+    process.env.NEXT_PUBLIC_EDUMATCH_URL,
   ]
     .filter((value): value is string => Boolean(value))
     .map((value) => {

--- a/apps/portal/app/(auth)/sign-up/page.tsx
+++ b/apps/portal/app/(auth)/sign-up/page.tsx
@@ -18,6 +18,9 @@ function isTrustedCallbackOrigin(origin: string): boolean {
   const allowList = [
     process.env.NEXT_PUBLIC_CONTENT_GENERATOR_URL,
     process.env.NEXT_PUBLIC_PORTAL_URL,
+    process.env.NEXT_PUBLIC_OPS_HUB_URL,
+    process.env.NEXT_PUBLIC_EDUMATCH_URL,
+    process.env.NEXT_PUBLIC_MARKETING_CONTENT_URL,
   ]
     .filter((value): value is string => Boolean(value))
     .map((value) => {

--- a/docs/issues/012-ops-hub-public-homepage.md
+++ b/docs/issues/012-ops-hub-public-homepage.md
@@ -1,0 +1,133 @@
+# Ops Hub Public Homepage Before Sign-In
+
+**Status:** Ready for development  
+**Priority:** High  
+**Assignee:** TBD  
+**Labels:** `enhancement`, `ops-hub`, `auth`, `homepage`, `ux`
+
+## Objective
+
+Add a public guest-facing homepage for the Ops Hub app so unauthenticated
+visitors can understand what the app is, what operational problems it solves,
+and why registration/sign-in is required before accessing the operator console.
+
+## Background
+
+When visiting the Ops Hub app directly at `http://localhost:3003/`, the current
+flow redirects immediately to the portal sign-in page:
+
+```text
+http://localhost:3000/sign-in?callbackUrl=http%3A%2F%2Flocalhost%3A3003%2F
+```
+
+That protects the internal console, but it gives guests no app-specific context.
+A first-time visitor should be able to see a concise public overview before
+being asked to sign in.
+
+The app on port `3003` maps to `apps/ops-hub`.
+
+## Problem
+
+- Guests see a sign-in wall before learning what Ops Hub is.
+- The current redirect does not explain that Ops Hub is an internal SaaS
+  operations console.
+- There is no public CTA explaining why authentication and proper permissions
+  are required.
+- The app lacks a first-touch onboarding surface for operators, admins, or
+  stakeholders evaluating the product.
+
+## Proposed Experience
+
+Unauthenticated users visiting `http://localhost:3003/` should see a public
+homepage with:
+
+- Clear product name and short explanation.
+- Summary of the operational workflows Ops Hub supports:
+  - tenant monitoring
+  - subscription and billing visibility
+  - user and customer lifecycle tracking
+  - feature flag operations
+  - automation monitoring
+  - audit history
+- Explanation that sign-in is required because the app contains business,
+  customer, billing, and operational data.
+- Primary CTA: sign in through the portal.
+- Secondary CTA: return to portal or learn more.
+
+Authenticated users with the right permissions should still land in the actual
+Ops Hub console.
+
+## Suggested Scope
+
+### 1. Split Guest and Authenticated Home Behavior
+
+- [ ] Update the root route or initial routing behavior in `apps/ops-hub`.
+- [ ] If the user has a valid session and Ops Hub access, render the current
+      authenticated console flow.
+- [ ] If the user is unauthenticated, render a public guest homepage instead of
+      immediately redirecting to sign-in.
+- [ ] If the user is authenticated but lacks `ops_viewer`, `ops_admin`, or
+      `superadmin`, continue showing the existing restricted-access experience.
+- [ ] Keep all operator data, APIs, and mutations protected.
+
+### 2. Create Public Homepage Content
+
+- [ ] Add a guest homepage section explaining what Ops Hub is.
+- [ ] Explain the value of a central operator console:
+  - spot at-risk tenants
+  - inspect subscription health
+  - manage rollout safely
+  - monitor automations
+  - review audit history
+- [ ] Add a clear message that registration/sign-in is required because the
+      console contains private operational data.
+- [ ] Include a concise CTA to sign in through the portal.
+
+### 3. CTA and Auth Flow
+
+- [ ] Add primary CTA to the portal sign-in/register flow.
+- [ ] Preserve callback behavior so users return to `http://localhost:3003/`
+      after authentication.
+- [ ] Confirm local callback URL behavior works with:
+
+```text
+http://localhost:3000/sign-in?callbackUrl=http%3A%2F%2Flocalhost%3A3003%2F
+```
+
+### 4. Design Requirements
+
+- [ ] Use the existing Ops Hub visual language and shared UI patterns.
+- [ ] Keep the page operational and product-focused, not a generic marketing
+      page.
+- [ ] Make the product purpose visible in the first viewport.
+- [ ] Avoid exposing tenant, billing, user, feature flag, automation, or audit
+      data to guests.
+- [ ] Ensure the mobile layout is clean and CTAs remain visible.
+
+### 5. Tests and Verification
+
+- [ ] Verify guest visit to `http://localhost:3003/` shows the public homepage.
+- [ ] Verify CTA sends user to portal sign-in/register.
+- [ ] Verify successful auth returns user to Ops Hub.
+- [ ] Verify authenticated users with Ops Hub permissions see the console.
+- [ ] Verify authenticated users without Ops Hub permissions see the restricted
+      access state.
+- [ ] Verify protected APIs still return unauthorized/forbidden for guests and
+      unauthorized users.
+
+## Acceptance Criteria
+
+- [ ] Guests can view a public Ops Hub homepage without signing in.
+- [ ] The homepage explains what Ops Hub does and why sign-in is required.
+- [ ] Registration/sign-in CTA preserves the callback URL back to the app.
+- [ ] Authorized users still see the existing operator console.
+- [ ] Unauthorized authenticated users still see the restricted-access flow.
+- [ ] No tenant, billing, user, feature flag, automation, or audit data is
+      exposed to unauthenticated users.
+- [ ] The issue is implemented without weakening route/API protection.
+
+## Notes
+
+This should be treated as a product onboarding improvement, not a request to
+make the Ops Hub console public. The console and all operational data must remain
+authenticated and permission-gated.

--- a/docs/ops-hub-project-plan.md
+++ b/docs/ops-hub-project-plan.md
@@ -1,0 +1,361 @@
+# Ops Hub Project Plan
+
+**Author:** Ali Safari
+**Created:** 2026-05-03
+**Status:** Operator MVP complete, public onboarding and production hardening next
+**Purpose:** Build a practical SaaS operations console for ASafariM Digital while
+practicing tenant operations, RBAC, feature control, lifecycle intelligence,
+automation monitoring, auditability, and business health workflows.
+
+## 1. Vision
+
+Ops Hub is the internal control room for a SaaS business. It should help an
+operator answer five questions quickly:
+
+1. Which tenants are healthy, stuck, at risk, or expanding?
+2. Which subscriptions, invoices, and usage patterns need attention?
+3. Which feature flags and automations are active, risky, or failing?
+4. What changed recently, who changed it, and why?
+5. What should the operator do next?
+
+The app should feel focused, dense, and operational. It is not a generic admin
+CRUD surface; it is a working console for repeated business operations.
+
+## 2. Current Implementation Snapshot
+
+Current app: `apps/ops-hub`
+
+Implemented:
+
+- Authenticated Next.js app using shared ASafariM auth.
+- `ops_viewer`, `ops_admin`, and `superadmin` access model.
+- KPI-first overview.
+- Tenant directory and tenant detail pages.
+- User directory.
+- Billing view for subscriptions and invoices.
+- Feature flag catalog with toggle mutations.
+- Lifecycle timeline.
+- Automation list and toggle mutations.
+- Audit log for operator mutations.
+- System health route and system page.
+- Public health endpoint.
+- Prisma models for tenants, plans, subscriptions, invoices, feature flags,
+  feature flag overrides, lifecycle events, usage metrics, automations,
+  automation runs, and audit logs.
+- Seed data that creates realistic tenant, billing, usage, lifecycle, feature
+  flag, automation, and audit scenarios.
+
+Known gaps:
+
+- Guest-facing product homepage is missing; direct visits redirect to sign-in.
+- No Stripe subscription sync yet.
+- No real alert destinations.
+- No support desk, CRM, or product analytics integrations.
+- No tenant health score beyond dashboard-level summaries.
+- No saved views or custom dashboards.
+- No operator playbooks.
+- No notification routing or escalation logic.
+
+## 3. Product Principles
+
+- Put action above administration: every screen should help an operator decide
+  what to inspect or do next.
+- Keep read-only access safe by default.
+- Audit every mutation that changes customer-facing or operational state.
+- Show reasons and context, not only raw records.
+- Prefer deterministic business rules before AI recommendations.
+- Make integrations additive; the local seeded demo should remain useful.
+
+## 4. Target Users
+
+- Founder/operator monitoring customer health.
+- Customer success lead triaging churn risk and expansion signals.
+- Finance/admin user inspecting invoices and subscriptions.
+- Product operator managing feature rollout and kill switches.
+- Support or engineering lead checking automation failures and audit history.
+
+## 5. Architecture
+
+```text
+Ops Hub UI (Next.js)
+          |
+          v
+Ops Hub API routes
+          |
+          +-- shared auth/session via @asafarim/auth
+          +-- RBAC checks in apps/ops-hub/lib/rbac.ts
+          +-- Prisma/Postgres via @asafarim/db
+          +-- audit logging in apps/ops-hub/lib/audit.ts
+          +-- system health checks
+          +-- seeded demo operational data
+```
+
+Future architecture additions:
+
+- Stripe sync workers for subscriptions, invoices, plans, and payments.
+- Alert dispatcher for Slack, email, and webhook destinations.
+- Support/CRM ingestion jobs.
+- Product analytics ingestion for usage and health scoring.
+- Operator notification center.
+- Playbook engine for repeated operational responses.
+
+## 6. Data Model Direction
+
+Existing concepts:
+
+- Tenant: customer account with status, region, industry, MRR, seats, and trial
+  lifecycle.
+- Plan: subscription catalog and feature defaults.
+- Subscription: tenant plan state, renewal, seats, and revenue.
+- Invoice: billing state and payment history.
+- Feature flag: global rollout control.
+- Feature flag override: tenant-specific rollout exception.
+- Lifecycle event: business and customer timeline.
+- Usage metric: weekly usage rollups.
+- Automation and automation run: scheduled/event-driven operational jobs.
+- Audit log: append-only record of operator mutations.
+
+Planned concepts:
+
+- Tenant health score: deterministic score with reason breakdown.
+- Risk signal: normalized churn, billing, usage, support, and lifecycle signals.
+- Playbook: repeatable operator response with tasks and owner.
+- Alert rule: condition, threshold, destination, and cooldown.
+- Saved view: filtered table or dashboard configuration.
+- Integration connection: Stripe, Slack, CRM, support desk, analytics provider.
+- Operator note: manual context attached to tenants, invoices, or events.
+- Incident: grouped automation failures or operational degradation.
+
+## 7. Milestones
+
+### Phase 0 - App Skeleton and Access Model (Complete)
+
+Deliverables:
+
+- Next.js app scaffold in `apps/ops-hub`.
+- Shared auth integration.
+- `ops_viewer`, `ops_admin`, and `superadmin` role model.
+- Public health endpoint.
+- Docker and deployment conventions.
+
+### Phase 1 - Operator Data Foundation (Complete)
+
+Deliverables:
+
+- Prisma schema additions for tenants, plans, subscriptions, invoices, feature
+  flags, overrides, lifecycle events, usage metrics, automations, automation
+  runs, and audit logs.
+- Seed script with realistic demo tenants and operational storylines.
+- Formatting helpers and RBAC helpers.
+
+### Phase 2 - Core Console MVP (Complete)
+
+Deliverables:
+
+- Overview page with KPI cards, risk queue, plan mix, and recent events.
+- Tenant directory with filters.
+- Tenant detail page with business, usage, billing, users, lifecycle, and flag
+  context.
+- Users, billing, feature flags, lifecycle, automations, and audit pages.
+- API routes for overview, tenants, feature flags, automations, and audit.
+- Audit logging for mutation routes.
+
+### Phase 3 - Public Product Homepage (Next)
+
+Goal: let guests understand Ops Hub before they hit the sign-in wall while
+keeping the actual console protected.
+
+Deliverables:
+
+- Public guest homepage at `http://localhost:3003/`.
+- Authenticated users with Ops Hub permissions continue into the console.
+- Authenticated users without Ops Hub permissions see the restricted-access
+  state.
+- Public copy explaining tenants, billing, lifecycle, flags, automations, and
+  audit history.
+- CTA to portal sign-in/register preserving callback URL.
+- Mobile-friendly public layout.
+
+Acceptance criteria:
+
+- Guest visit to `/` shows a public Ops Hub overview.
+- No tenant, billing, user, feature flag, automation, or audit data is exposed.
+- Sign-in returns authorized users to the Ops Hub console.
+
+### Phase 4 - Stripe Billing Sync
+
+Goal: move billing from seeded demo data toward real subscription operations.
+
+Deliverables:
+
+- Stripe customer/subscription/invoice mapping strategy.
+- Sync job for plans, subscriptions, invoices, and payment state.
+- Webhook handling for subscription and invoice lifecycle events.
+- Billing reconciliation page showing last sync, source state, and local state.
+- Manual resync action gated to `ops_admin`.
+- Audit records for manual sync actions.
+
+Acceptance criteria:
+
+- Operators can see whether billing data is current.
+- Subscription and invoice status changes are traceable to Stripe events.
+
+### Phase 5 - Tenant Health Scoring
+
+Goal: make risk and expansion signals explicit.
+
+Deliverables:
+
+- Deterministic health score with reason breakdown.
+- Inputs from subscription state, invoice status, usage trend, lifecycle events,
+  seat utilization, and support/automation signals.
+- Health badge on overview, tenant list, and tenant detail.
+- Risk queue sorted by severity and freshness.
+- Expansion queue for high-usage or plan-limit tenants.
+- Tests for scoring rules.
+
+Creative milestone:
+
+- "Why this tenant needs attention" summary that explains the score in plain
+  operator language.
+
+### Phase 6 - Alerts and Escalation
+
+Goal: notify operators when business-critical state changes.
+
+Deliverables:
+
+- Alert rule model.
+- Alert destinations for email, Slack/webhook, and in-app notification.
+- Conditions for past-due invoice, churn-risk event, automation failure,
+  sudden usage drop, trial ending, and feature flag incident.
+- Cooldown and dedupe logic.
+- Alert run history.
+- Admin UI for enabling/disabling alert rules.
+
+Acceptance criteria:
+
+- Operators can trace why an alert fired and whether it was delivered.
+
+### Phase 7 - Playbooks
+
+Goal: turn repeated operations into guided workflows.
+
+Deliverables:
+
+- Playbook model with trigger, steps, owner, due date, and completion state.
+- Built-in playbooks:
+  - past-due recovery
+  - churn risk outreach
+  - trial conversion
+  - enterprise expansion
+  - failed automation follow-up
+  - feature rollout verification
+- Tenant detail playbook panel.
+- Activity timeline entries when playbooks start/finish.
+- Audit events for playbook actions.
+
+Creative milestone:
+
+- "Operator briefing" that summarizes active playbooks and next actions for the
+  day.
+
+### Phase 8 - Integrations
+
+Goal: make Ops Hub reflect real operational systems.
+
+Deliverables:
+
+- Integration connection settings.
+- Stripe as first production integration.
+- Support desk ingestion plan for tickets and satisfaction signals.
+- CRM ingestion plan for lifecycle and account-owner signals.
+- Product analytics ingestion plan for usage metrics.
+- Webhook receiver for custom events.
+- Integration health dashboard.
+
+Acceptance criteria:
+
+- Operators can see whether each integration is connected, stale, failing, or
+  healthy.
+
+### Phase 9 - Saved Views and Custom Dashboards
+
+Goal: let different operators keep the view they need.
+
+Deliverables:
+
+- Saved filters for tenants, billing, lifecycle, audit, and automations.
+- Custom dashboard cards selected from available metrics.
+- Role-aware defaults for founder, finance, customer success, product, and
+  support views.
+- Shareable saved views inside the tenant.
+- URL-stable filter state.
+
+### Phase 10 - Operational Intelligence
+
+Goal: move from reporting to recommendations.
+
+Deliverables:
+
+- Daily operations digest.
+- Tenant anomaly detection for usage and billing.
+- Recommended next action based on health score and lifecycle state.
+- Natural-language audit and lifecycle summaries.
+- AI-assisted incident summary for grouped automation failures.
+- "What changed since yesterday?" operator view.
+
+## 8. Release Plan
+
+1. Internal MVP: current console with seeded data.
+2. Public onboarding patch: guest homepage before sign-in.
+3. Billing alpha: Stripe sync in test mode.
+4. Health-score beta: deterministic risk/expansion queues.
+5. Alerts beta: in-app and email/Slack destinations.
+6. Playbook beta: guided operator workflows.
+7. Integration beta: support, CRM, and analytics ingestion.
+8. Portfolio/demo release: screenshots, seeded walkthrough, and architecture
+   notes.
+
+## 9. Testing Plan
+
+- Unit tests for RBAC checks, audit payloads, formatting, health scoring, and
+  alert rule evaluation.
+- API tests for unauthorized, forbidden, read-only, and admin mutation paths.
+- Integration tests for Stripe sync and webhook idempotency.
+- UI tests for overview, tenant filters, tenant detail, feature flag toggles,
+  automation toggles, and audit visibility.
+- Manual QA for seeded demo walkthrough and public homepage auth transitions.
+
+## 10. Operational Risks
+
+- Exposing private data on public routes. Mitigation: strict guest page split and
+  API auth tests.
+- Incorrect billing state. Mitigation: Stripe event IDs, sync timestamps,
+  reconciliation UI, and audit trails.
+- Alert fatigue. Mitigation: severity, cooldowns, dedupe, and operator
+  ownership.
+- Health score distrust. Mitigation: transparent reason breakdown and rule tests.
+- Mutation safety. Mitigation: `ops_viewer` read-only role, audit logs, and
+  explicit admin gates.
+
+## 11. Out of Scope for v1
+
+- Replacing a full CRM.
+- Replacing a full support desk.
+- Fully autonomous customer outreach.
+- Complex enterprise approval chains.
+- Multi-region incident management.
+- Production financial reporting beyond operational billing visibility.
+
+## 12. Documentation Ownership
+
+- App operations: `apps/ops-hub/README.md`
+- Product and milestone plan: this file
+- Public homepage issue: `docs/issues/012-ops-hub-public-homepage.md`
+- Database truth: `packages/db/prisma/schema.prisma`
+- RBAC truth: `apps/ops-hub/lib/rbac.ts`
+- Audit behavior: `apps/ops-hub/lib/audit.ts`
+
+Update this plan whenever a milestone changes status or a new operational
+surface becomes part of the product direction.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -9,7 +9,8 @@ function getCookieDomain(): string | undefined {
   const domain = process.env.AUTH_COOKIE_DOMAIN;
   if (domain) return domain;
   if (process.env.NODE_ENV === "production") return ".asafarim.com";
-  return undefined;
+  // In development, use localhost to share cookies across ports
+  return "localhost";
 }
 
 function slugifyUsername(value: string): string {
@@ -98,6 +99,32 @@ export const authConfig: NextAuthConfig = {
   },
 
   callbacks: {
+    async redirect({ url, baseUrl }) {
+      // Allows relative callback URLs
+      if (url.startsWith("/")) return `${baseUrl}${url}`;
+      // Allows callback URLs on the same origin
+      if (new URL(url).origin === baseUrl) return url;
+      // Allow cross-origin callbacks for trusted domains
+      const trustedOrigins = [
+        process.env.NEXT_PUBLIC_PORTAL_URL,
+        process.env.NEXT_PUBLIC_CONTENT_GENERATOR_URL,
+        process.env.NEXT_PUBLIC_OPS_HUB_URL,
+        process.env.NEXT_PUBLIC_EDUMATCH_URL,
+        process.env.NEXT_PUBLIC_MARKETING_CONTENT_URL,
+      ]
+        .filter((u): u is string => Boolean(u))
+        .map((u) => new URL(u).origin);
+      
+      try {
+        const urlOrigin = new URL(url).origin;
+        if (trustedOrigins.includes(urlOrigin)) return url;
+      } catch {
+        // ignore invalid URLs
+      }
+      
+      return baseUrl;
+    },
+
     async jwt({ token, user, trigger }) {
       if (user) {
         const dbUser = await prisma.user.findUnique({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.3
-        version: 16.2.3(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       postcss:
         specifier: ^8.5.0
         version: 8.5.9
@@ -168,7 +168,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.3
-        version: 16.2.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.3(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       node-mocks-http:
         specifier: ^1.15.1
         version: 1.17.2(@types/node@22.19.17)
@@ -248,6 +248,9 @@ importers:
       '@asafarim/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      lucide-react:
+        specifier: ^0.462.0
+        version: 0.462.0(react@19.2.5)
       next:
         specifier: ^15.3.0
         version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
- Convert ops-hub root page to async server component with auth-based routing
- Add PublicHomepage component for unauthenticated users
- Update layout to skip Shell and RBAC checks for unauthenticated visitors
- Allow unauthenticated access to ops-hub homepage (/) in middleware
- Add lucide-react dependency to ops-hub package
- Implement redirect callback in auth config to allow trusted cross-origin redirects
- Add ops-hub, ed

Refs #28