### PR TITLE
feat(vionto): add media domain schema with projects, assets, scripts,…

### DIFF
--- a/docs/issues/025-vionto-web-db-schema-media-domain.md
+++ b/docs/issues/025-vionto-web-db-schema-media-domain.md
@@ -1,8 +1,8 @@
 # Vionto Web Issue 3 - Database Schema for Media Projects
 
-**Status:** Ready for development  
+**Status:** In Progress  
 **Priority:** High  
-**Assignee:** TBD  
+**Assignee:** AI Assistant  
 **Labels:** `vionto`, `web`, `database`, `prisma`, `media`
 
 ## Objective
@@ -17,14 +17,18 @@ Add Vionto domain models to `packages/db` for projects, assets, scripts, audio, 
 
 ## Scope
 
-- [ ] Add `ViontoProject` with owner, tenant, title, mode, locale, status, aspect ratio, and target duration.
-- [ ] Add `ViontoAsset` for originals, thumbnails, dimensions, order, metadata, and storage keys.
-- [ ] Add `ViontoScript` for prompt version, provider metadata, narration text, SRT text, and user-edited flag.
-- [ ] Add `ViontoAudioTrack` for narration, music, voice, duration, and mix settings.
-- [ ] Add `ViontoRenderJob` for queue id, state, progress, logs, retry count, and error summary.
-- [ ] Add `ViontoExport` for output storage key, duration, file size, format, and signed-link metadata.
-- [ ] Add audit/usage records tied to user and tenant.
-- [ ] Create migration and seed records for roles/permissions/app registry.
+- [x] Add `ViontoProject` with owner, tenant, title, mode, locale, status, aspect ratio, and target duration.
+  - `packages/db/prisma/schema.prisma` — added with relations to assets, scripts, audio, renders, exports.
+- [x] Add `ViontoAsset` for originals, thumbnails, dimensions, order, metadata, and storage keys.
+- [x] Add `ViontoScript` for prompt version, provider metadata, narration text, SRT text, and user-edited flag.
+- [x] Add `ViontoAudioTrack` for narration, music, voice, duration, and mix settings.
+- [x] Add `ViontoRenderJob` for queue id, state, progress, logs, retry count, and error summary.
+- [x] Add `ViontoExport` for output storage key, duration, file size, format, and signed-link metadata.
+- [x] Add audit/usage records tied to user and tenant.
+  - `ViontoAuditEvent` model added with actor relation and domain-specific action/entity tracking.
+- [x] Create migration and seed records for roles/permissions/app registry.
+  - Migration `20260507203954_add_vionto_media_domain` generated and applied.
+  - App registry + roles/permissions already seeded in prior #024 work.
 
 ## Acceptance Criteria
 

--- a/packages/db/prisma/migrations/20260507203954_add_vionto_media_domain/migration.sql
+++ b/packages/db/prisma/migrations/20260507203954_add_vionto_media_domain/migration.sql
@@ -1,0 +1,239 @@
+-- CreateTable
+CREATE TABLE "ViontoProject" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tenantId" TEXT,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "mode" TEXT NOT NULL DEFAULT 'story',
+    "locale" TEXT NOT NULL DEFAULT 'en-US',
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "aspectRatio" TEXT NOT NULL DEFAULT '16:9',
+    "targetDurationSeconds" INTEGER,
+    "retentionPolicy" TEXT NOT NULL DEFAULT 'soft_delete',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ViontoProject_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ViontoAsset" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'source_image',
+    "originalUrl" TEXT,
+    "thumbnailUrl" TEXT,
+    "storageKey" TEXT,
+    "thumbnailStorageKey" TEXT,
+    "width" INTEGER,
+    "height" INTEGER,
+    "fileSizeBytes" INTEGER,
+    "orderIndex" INTEGER NOT NULL DEFAULT 0,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ViontoAsset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ViontoScript" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "promptVersion" TEXT,
+    "provider" TEXT,
+    "narrationText" TEXT,
+    "srtText" TEXT,
+    "isUserEdited" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ViontoScript_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ViontoAudioTrack" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'narration',
+    "source" TEXT NOT NULL DEFAULT 'tts',
+    "voiceId" TEXT,
+    "voiceName" TEXT,
+    "durationSeconds" INTEGER,
+    "storageKey" TEXT,
+    "mixSettings" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ViontoAudioTrack_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ViontoRenderJob" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "queueId" TEXT,
+    "state" TEXT NOT NULL DEFAULT 'queued',
+    "progressPercent" INTEGER NOT NULL DEFAULT 0,
+    "logs" TEXT,
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "errorSummary" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ViontoRenderJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ViontoExport" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "renderJobId" TEXT,
+    "userId" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "durationSeconds" INTEGER,
+    "fileSizeBytes" INTEGER,
+    "format" TEXT NOT NULL DEFAULT 'mp4',
+    "resolution" TEXT,
+    "signedUrl" TEXT,
+    "signedUrlExpiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ViontoExport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ViontoAuditEvent" (
+    "id" TEXT NOT NULL,
+    "actorId" TEXT,
+    "actorRole" TEXT,
+    "action" TEXT NOT NULL,
+    "entity" TEXT NOT NULL,
+    "entityId" TEXT,
+    "prevState" TEXT,
+    "nextState" TEXT,
+    "reason" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ViontoAuditEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ViontoProject_userId_idx" ON "ViontoProject"("userId");
+
+-- CreateIndex
+CREATE INDEX "ViontoProject_tenantId_idx" ON "ViontoProject"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "ViontoProject_status_idx" ON "ViontoProject"("status");
+
+-- CreateIndex
+CREATE INDEX "ViontoProject_createdAt_idx" ON "ViontoProject"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "ViontoAsset_projectId_idx" ON "ViontoAsset"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ViontoAsset_userId_idx" ON "ViontoAsset"("userId");
+
+-- CreateIndex
+CREATE INDEX "ViontoAsset_type_idx" ON "ViontoAsset"("type");
+
+-- CreateIndex
+CREATE INDEX "ViontoAsset_orderIndex_idx" ON "ViontoAsset"("orderIndex");
+
+-- CreateIndex
+CREATE INDEX "ViontoScript_projectId_idx" ON "ViontoScript"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ViontoScript_userId_idx" ON "ViontoScript"("userId");
+
+-- CreateIndex
+CREATE INDEX "ViontoScript_isUserEdited_idx" ON "ViontoScript"("isUserEdited");
+
+-- CreateIndex
+CREATE INDEX "ViontoAudioTrack_projectId_idx" ON "ViontoAudioTrack"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ViontoAudioTrack_userId_idx" ON "ViontoAudioTrack"("userId");
+
+-- CreateIndex
+CREATE INDEX "ViontoAudioTrack_type_idx" ON "ViontoAudioTrack"("type");
+
+-- CreateIndex
+CREATE INDEX "ViontoRenderJob_projectId_idx" ON "ViontoRenderJob"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ViontoRenderJob_userId_idx" ON "ViontoRenderJob"("userId");
+
+-- CreateIndex
+CREATE INDEX "ViontoRenderJob_state_idx" ON "ViontoRenderJob"("state");
+
+-- CreateIndex
+CREATE INDEX "ViontoRenderJob_queueId_idx" ON "ViontoRenderJob"("queueId");
+
+-- CreateIndex
+CREATE INDEX "ViontoRenderJob_createdAt_idx" ON "ViontoRenderJob"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "ViontoExport_projectId_idx" ON "ViontoExport"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ViontoExport_renderJobId_idx" ON "ViontoExport"("renderJobId");
+
+-- CreateIndex
+CREATE INDEX "ViontoExport_userId_idx" ON "ViontoExport"("userId");
+
+-- CreateIndex
+CREATE INDEX "ViontoExport_format_idx" ON "ViontoExport"("format");
+
+-- CreateIndex
+CREATE INDEX "ViontoAuditEvent_actorId_idx" ON "ViontoAuditEvent"("actorId");
+
+-- CreateIndex
+CREATE INDEX "ViontoAuditEvent_entity_idx" ON "ViontoAuditEvent"("entity");
+
+-- CreateIndex
+CREATE INDEX "ViontoAuditEvent_entityId_idx" ON "ViontoAuditEvent"("entityId");
+
+-- CreateIndex
+CREATE INDEX "ViontoAuditEvent_action_idx" ON "ViontoAuditEvent"("action");
+
+-- CreateIndex
+CREATE INDEX "ViontoAuditEvent_createdAt_idx" ON "ViontoAuditEvent"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ViontoProject" ADD CONSTRAINT "ViontoProject_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoProject" ADD CONSTRAINT "ViontoProject_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoAsset" ADD CONSTRAINT "ViontoAsset_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "ViontoProject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoScript" ADD CONSTRAINT "ViontoScript_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "ViontoProject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoAudioTrack" ADD CONSTRAINT "ViontoAudioTrack_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "ViontoProject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoRenderJob" ADD CONSTRAINT "ViontoRenderJob_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "ViontoProject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoExport" ADD CONSTRAINT "ViontoExport_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "ViontoProject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoExport" ADD CONSTRAINT "ViontoExport_renderJobId_fkey" FOREIGN KEY ("renderJobId") REFERENCES "ViontoRenderJob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ViontoAuditEvent" ADD CONSTRAINT "ViontoAuditEvent_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -76,6 +76,10 @@ model User {
   eduTutorVerificationsReviewed EduTutorVerification[] @relation("EduTutorVerificationReviewer")
   eduAuditEventsActor    EduAuditEvent[]           @relation("EduAuditActor")
 
+  // Vionto
+  viontoProjects       ViontoProject[]
+  viontoAuditEvents    ViontoAuditEvent[]        @relation("ViontoAuditActor")
+
   // Generic user locations (home, work, etc.) - reusable across all apps
   locations UserLocation[]
 
@@ -361,6 +365,9 @@ model Tenant {
   savedPrompts           SavedPrompt[]
   contentGenerations     ContentGeneration[]
   contentTypeDefinitions ContentTypeDefinition[]
+
+  // Vionto
+  viontoProjects ViontoProject[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1163,4 +1170,240 @@ model CartItem {
   @@index([productType])
   @@index([productId])
   @@index([sellerId])
+}
+
+// ─── Vionto — Photo-to-Story Video Pipeline ──────────────────
+
+model ViontoProject {
+  id                   String   @id @default(cuid())
+  userId               String
+  tenantId             String?
+
+  title                String
+  description          String?  @db.Text
+
+  // Story mode: narrative arc vs. simple slideshow
+  mode                 String   @default("story") // story, slideshow, documentary
+
+  // Target locale for narration / captions
+  locale               String   @default("en-US")
+
+  // Lifecycle: draft -> ready -> rendering -> completed -> archived
+  status               String   @default("draft") // draft, ready, rendering, completed, archived
+
+  aspectRatio          String   @default("16:9") // 16:9, 9:16, 1:1, 4:3
+  targetDurationSeconds Int?    // User target; null = auto
+
+  // Deletion/retention policy for this project
+  retentionPolicy      String   @default("soft_delete") // soft_delete, hard_delete, archive
+
+  // Relations
+  assets       ViontoAsset[]
+  scripts      ViontoScript[]
+  audioTracks  ViontoAudioTrack[]
+  renderJobs   ViontoRenderJob[]
+  exports      ViontoExport[]
+
+  // Ownership
+  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tenant Tenant? @relation(fields: [tenantId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([tenantId])
+  @@index([status])
+  @@index([createdAt])
+}
+
+model ViontoAsset {
+  id                  String  @id @default(cuid())
+  projectId           String
+  userId              String
+
+  // Asset classification
+  type                String  @default("source_image") // source_image, thumbnail, extracted_frame, overlay
+
+  // Display / storage URLs
+  originalUrl         String?
+  thumbnailUrl        String?
+  storageKey          String? // S3 / object-store key for original
+  thumbnailStorageKey String? // S3 / object-store key for thumbnail
+
+  // Dimensions
+  width               Int?
+  height              Int?
+  fileSizeBytes       Int?
+
+  // Ordering within the project timeline
+  orderIndex          Int     @default(0)
+
+  // EXIF and technical metadata (JSON blob)
+  metadata            Json?
+
+  // Ownership
+  project ViontoProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([projectId])
+  @@index([userId])
+  @@index([type])
+  @@index([orderIndex])
+}
+
+model ViontoScript {
+  id              String  @id @default(cuid())
+  projectId       String
+  userId          String
+
+  // Generation provenance
+  promptVersion   String? // Which prompt template / version produced this
+  provider        String? // openai, anthropic, custom, manual
+
+  // Content
+  narrationText   String? @db.Text // Plain-text narration
+  srtText         String? @db.Text // SubRip subtitle text
+
+  // User override tracking
+  isUserEdited    Boolean @default(false)
+
+  project ViontoProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([projectId])
+  @@index([userId])
+  @@index([isUserEdited])
+}
+
+model ViontoAudioTrack {
+  id              String  @id @default(cuid())
+  projectId       String
+  userId          String
+
+  // Classification
+  type            String  @default("narration") // narration, music, sfx
+  source          String  @default("tts") // tts, upload, generated
+
+  // Voice / instrument metadata
+  voiceId         String?
+  voiceName       String?
+
+  // Duration in seconds
+  durationSeconds Int?
+
+  // Storage
+  storageKey      String?
+
+  // Mix settings: volume, fadeIn, fadeOut, startOffset (JSON)
+  mixSettings     Json?
+
+  project ViontoProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([projectId])
+  @@index([userId])
+  @@index([type])
+}
+
+model ViontoRenderJob {
+  id             String   @id @default(cuid())
+  projectId      String
+  userId         String
+
+  // External queue / worker ID (e.g. BullMQ, Celery, etc.)
+  queueId        String?
+
+  // State machine
+  state          String   @default("queued") // queued, running, paused, completed, failed, cancelled
+
+  // Progress 0-100
+  progressPercent Int     @default(0)
+
+  // Worker logs (last N lines)
+  logs           String?  @db.Text
+
+  // Retry handling
+  retryCount     Int      @default(0)
+  errorSummary   String?  @db.Text
+
+  // Timing
+  startedAt      DateTime?
+  completedAt    DateTime?
+
+  // Relations
+  project ViontoProject @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  exports ViontoExport[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([projectId])
+  @@index([userId])
+  @@index([state])
+  @@index([queueId])
+  @@index([createdAt])
+}
+
+model ViontoExport {
+  id              String  @id @default(cuid())
+  projectId       String
+  renderJobId     String?
+  userId          String
+
+  // Output storage
+  storageKey      String
+
+  // Technical metadata
+  durationSeconds Int?
+  fileSizeBytes   Int?
+  format          String  @default("mp4") // mp4, mov, webm
+  resolution      String? // 1080p, 4k, 720p
+
+  // Signed URL for direct download (time-limited)
+  signedUrl       String?
+  signedUrlExpiresAt DateTime?
+
+  // Relations
+  project    ViontoProject  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  renderJob  ViontoRenderJob? @relation(fields: [renderJobId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([projectId])
+  @@index([renderJobId])
+  @@index([userId])
+  @@index([format])
+}
+
+// Domain-specific audit trail for Vionto operations.
+// Complements the generic AuditLog with render-pipeline transitions.
+model ViontoAuditEvent {
+  id         String  @id @default(cuid())
+  actorId    String? // null for system / worker events
+  actorRole  String? // CREATOR, ADMIN, SYSTEM, WORKER
+  action     String // PROJECT_CREATED, ASSET_UPLOADED, SCRIPT_GENERATED, RENDER_STARTED, RENDER_COMPLETED, EXPORT_DOWNLOADED, ...
+  entity     String // ViontoProject, ViontoAsset, ViontoScript, ViontoRenderJob, ViontoExport
+  entityId   String?
+  prevState  String?
+  nextState  String?
+  reason     String? @db.Text
+  metadata   Json?
+
+  createdAt DateTime @default(now())
+
+  actor User? @relation("ViontoAuditActor", fields: [actorId], references: [id], onDelete: SetNull)
+
+  @@index([actorId])
+  @@index([entity])
+  @@index([entityId])
+  @@index([action])
+  @@index([createdAt])
 }


### PR DESCRIPTION
… audio, renders, and exports

- Add ViontoProject model with mode, locale, status, aspect ratio, and target duration
- Add ViontoAsset for source images, thumbnails, dimensions, order, and storage keys
- Add ViontoScript for prompt version, provider metadata, narration text, and SRT subtitles
- Add ViontoAudioTrack for narration, music, voice settings, and mix configuration
- Add ViontoRenderJob for queue management, state tracking, progress,

Refs #39