### PR TITLE
feat: add video versioning per album (#78)

### DIFF
--- a/apps/vionto/components/ViontoPage.tsx
+++ b/apps/vionto/components/ViontoPage.tsx
@@ -892,13 +892,16 @@ export function ViontoPage() {
     }
   }
 
-  async function createVideoVersion(name?: string) {
+  async function createVideoVersion(name?: string, albumId?: string | null) {
     if (!selectedProjectId) return;
     try {
       const res = await fetch(`/api/projects/${selectedProjectId}/versions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: name || `Version ${videoVersions.length + 1}` }),
+        body: JSON.stringify({
+          name: name || `Version ${videoVersions.length + 1}`,
+          ...(albumId && { albumId }),
+        }),
       });
       if (!res.ok) return;
       const data = await res.json();
@@ -2058,7 +2061,7 @@ export function ViontoPage() {
                     </label>
                     <button
                       type="button"
-                      onClick={() => createVideoVersion()}
+                      onClick={() => createVideoVersion(undefined, selectedAlbumId)}
                       className="text-xs font-medium text-[var(--color-accent)] hover:underline flex items-center gap-1"
                     >
                       <Plus size={11} /> New version
@@ -2119,7 +2122,14 @@ export function ViontoPage() {
                               </button>
                             </form>
                           ) : (
-                            <span>{version.name}</span>
+                            <>
+                              <span>{version.name}</span>
+                              {version.albumId && (
+                                <span className="ml-1 rounded bg-[var(--color-surface)] px-1 py-0.5 text-[9px] text-[var(--color-text-muted)]">
+                                  {albums.find((a) => a.id === version.albumId)?.name ?? "Album"}
+                                </span>
+                              )}
+                            </>
                           )}
 
                           {/* Action buttons - show on hover for active tab */}
@@ -2564,6 +2574,21 @@ export function ViontoPage() {
                               {isSorting ? <RefreshCw size={12} className="animate-spin" /> : <MapPin size={12} />}
                               Group by location
                             </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const albumVersions = videoVersions.filter((v) => v.albumId === selectedAlbumId);
+                                createVideoVersion(
+                                  `${selectedAlbum?.name} - Version ${albumVersions.length + 1}`,
+                                  selectedAlbumId,
+                                );
+                              }}
+                              className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2 py-1 text-xs font-medium text-[var(--color-text)] hover:border-[var(--color-accent)] transition-colors"
+                              title="Create a new video version linked to this album"
+                            >
+                              <Clapperboard size={12} />
+                              New version
+                            </button>
                           </div>
                         </div>
                       )}
@@ -2632,6 +2657,32 @@ export function ViontoPage() {
                           </div>
                         </div>
                       )}
+
+                      {/* Linked video versions for this album */}
+                      {selectedAlbum && !isBaseAlbumSelected && (() => {
+                        const albumVersions = videoVersions.filter((v) => v.albumId === selectedAlbumId);
+                        if (albumVersions.length === 0) return null;
+                        return (
+                          <div className="mb-2 flex items-center gap-1.5 flex-wrap">
+                            <span className="text-[10px] font-medium text-[var(--color-text-muted)]">Versions:</span>
+                            {albumVersions.map((v) => (
+                              <button
+                                key={v.id}
+                                type="button"
+                                onClick={() => setSelectedVersionId(v.id)}
+                                className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                                  v.id === selectedVersionId
+                                    ? "border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]"
+                                    : "border-[var(--color-border)] bg-[var(--color-surface-soft)] text-[var(--color-text-muted)] hover:border-[var(--color-accent)]/50"
+                                }`}
+                              >
+                                <Clapperboard size={9} />
+                                {v.name}
+                              </button>
+                            ))}
+                          </div>
+                        );
+                      })()}
 
                       {/* Add images panel */}
                       {showAddImages && !isBaseAlbumSelected && (


### PR DESCRIPTION
## Summary
- **Album-linked versions**: New video versions created from the version selector or album toolbar are automatically linked to the currently selected album via `albumId`
- **Album badges on version tabs**: Version tabs now show a small badge with the album name when linked to an album, making it easy to see which album each version renders from
- **"New version" button in album toolbar**: Non-base albums gain a dedicated button to create a version pre-named after the album (e.g. "Wedding - Version 2")
- **Linked versions section**: Below the album toolbar, clickable version chips let users jump directly to versions that render from the selected album

## Test plan
- [ ] Select an album, click "New version" in the album toolbar — verify the created version has `albumId` set and is named after the album
- [ ] Check version tabs show album name badges for linked versions
- [ ] Click "New version" in the version selector — verify it links to the currently selected album
- [ ] Check the album section shows linked versions with clickable buttons that switch the active version
- [ ] Duplicate a version — verify the clone inherits the albumId
- [ ] Delete a version — verify album photos remain intact
- [ ] Select a version tab linked to an album — verify it displays correctly

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video versions can now be created and linked to specific albums
  * Version badges display the associated album name
  * Album toolbar includes a "New version" button to create linked versions
  * New "Linked video versions" section allows viewing and switching between versions tied to an album

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AliSafari-IT/asafarim-digital/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->