### PR TITLE
feat(vionto): story structure controls & caption overlays

### DIFF
--- a/apps/vionto/app/api/projects/[projectId]/versions/[versionId]/route.ts
+++ b/apps/vionto/app/api/projects/[projectId]/versions/[versionId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@asafarim/db";
+import { Prisma, prisma } from "@asafarim/db";
 import {
   getAuthedUser,
   unauthorized,
@@ -30,6 +30,8 @@ const VERSION_SELECT = {
   aspectRatio: true,
   resolution: true,
   targetDurationSeconds: true,
+  storyStructure: true,
+  captionOverlaySettings: true,
   createdAt: true,
   updatedAt: true,
   _count: { select: { scripts: true, renderJobs: true, exports: true } },
@@ -119,9 +121,17 @@ export async function PATCH(req: Request, { params }: RouteParams) {
       if (!album) return badRequest("Album not found.");
     }
 
+    // Transform null JSON values for Prisma compatibility
+    const updateData: Record<string, unknown> = { ...parsed.data };
+    for (const key of ["storyStructure", "captionOverlaySettings", "subtitleSettings", "musicMetadata"] as const) {
+      if (key in updateData && updateData[key] === null) {
+        updateData[key] = Prisma.JsonNull;
+      }
+    }
+
     const updated = await prisma.viontoVideoVersion.update({
       where: { id: versionId },
-      data: parsed.data,
+      data: updateData as any,
       select: VERSION_SELECT,
     });
 

--- a/apps/vionto/app/api/projects/[projectId]/versions/route.ts
+++ b/apps/vionto/app/api/projects/[projectId]/versions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@asafarim/db";
+import { Prisma, prisma } from "@asafarim/db";
 import { getAuthedUser, unauthorized, badRequest, serverError } from "@/lib/server/auth";
 import { createVideoVersionSchema, formatZodError } from "@/lib/server/validation";
 
@@ -23,6 +23,8 @@ const VERSION_SELECT = {
   aspectRatio: true,
   resolution: true,
   targetDurationSeconds: true,
+  storyStructure: true,
+  captionOverlaySettings: true,
   createdAt: true,
   updatedAt: true,
   _count: { select: { scripts: true, renderJobs: true, exports: true } },
@@ -115,6 +117,8 @@ export async function POST(
           aspectRatio: true,
           resolution: true,
           targetDurationSeconds: true,
+          storyStructure: true,
+          captionOverlaySettings: true,
         },
       });
       if (!source) return badRequest("Source version not found.");
@@ -131,14 +135,22 @@ export async function POST(
       if (!album) return badRequest("Album not found.");
     }
 
+    // Transform null JSON values for Prisma compatibility
+    const createData: Record<string, unknown> = {
+      projectId,
+      userId: user.id,
+      ...cloneData,
+      ...data,
+      albumId: effectiveAlbumId,
+    };
+    for (const key of ["storyStructure", "captionOverlaySettings", "subtitleSettings", "musicMetadata"] as const) {
+      if (key in createData && createData[key] === null) {
+        createData[key] = Prisma.JsonNull;
+      }
+    }
+
     const version = await prisma.viontoVideoVersion.create({
-      data: {
-        projectId,
-        userId: user.id,
-        ...cloneData,
-        ...data,
-        albumId: effectiveAlbumId,
-      },
+      data: createData as any,
       select: VERSION_SELECT,
     });
 

--- a/apps/vionto/app/api/render/route.ts
+++ b/apps/vionto/app/api/render/route.ts
@@ -122,7 +122,7 @@ export async function POST(req: Request) {
     if (versionId) {
       const version = await prisma.viontoVideoVersion.findFirst({
         where: { id: versionId, projectId },
-        select: { id: true, albumId: true, mode: true, aspectRatio: true, resolution: true, visualStyle: true, musicOption: true, musicTrackId: true, musicMetadata: true, musicUploadKey: true, emotionalTone: true, storyMode: true, subtitleSettings: true, targetDurationSeconds: true },
+        select: { id: true, albumId: true, mode: true, aspectRatio: true, resolution: true, visualStyle: true, musicOption: true, musicTrackId: true, musicMetadata: true, musicUploadKey: true, emotionalTone: true, storyMode: true, subtitleSettings: true, targetDurationSeconds: true, storyStructure: true, captionOverlaySettings: true },
       });
       if (!version) return badRequest("Video version not found.");
       // Merge version settings with project locale (which stays on the project)
@@ -392,6 +392,9 @@ export async function POST(req: Request) {
         subtitleStyle: subtitleConfig.style,
         subtitleTiming: subtitleConfig.timing,
         subtitleExport: subtitleConfig.exportOpts,
+        // Story structure & caption overlays (#102)
+        ...((settings as any).storyStructure ? { storyStructure: (settings as any).storyStructure } : {}),
+        ...((settings as any).captionOverlaySettings ? { captionOverlaySettings: (settings as any).captionOverlaySettings } : {}),
         audioTracks: [
           ...audioTracks
             .filter((track) => track.storageKey || track.voiceId)

--- a/apps/vionto/app/api/story/generate/route.ts
+++ b/apps/vionto/app/api/story/generate/route.ts
@@ -70,11 +70,11 @@ export async function POST(req: Request) {
 
     // If a versionId is provided, load creative settings from the version.
     // Otherwise fall back to project-level settings (backward compat).
-    let versionRecord: { id: string; albumId: string | null; mode: string; storyMode: string | null; emotionalTone: string | null; visualStyle: string | null; musicOption: string | null; targetDurationSeconds: number | null } | null = null;
+    let versionRecord: { id: string; albumId: string | null; mode: string; storyMode: string | null; emotionalTone: string | null; visualStyle: string | null; musicOption: string | null; targetDurationSeconds: number | null; storyStructure: unknown; captionOverlaySettings: unknown } | null = null;
     if (versionId && typeof versionId === "string") {
       versionRecord = await prisma.viontoVideoVersion.findFirst({
         where: { id: versionId, projectId },
-        select: { id: true, albumId: true, mode: true, storyMode: true, emotionalTone: true, visualStyle: true, musicOption: true, targetDurationSeconds: true },
+        select: { id: true, albumId: true, mode: true, storyMode: true, emotionalTone: true, visualStyle: true, musicOption: true, targetDurationSeconds: true, storyStructure: true, captionOverlaySettings: true },
       });
       if (!versionRecord) return badRequest("Video version not found.");
     }
@@ -244,6 +244,12 @@ export async function POST(req: Request) {
     }
 
     const systemPrompt = buildStorySystemPrompt(effectiveLocale);
+    // Parse story structure from the version if available
+    const rawStoryStructure = versionRecord?.storyStructure;
+    const storyStructure = rawStoryStructure && typeof rawStoryStructure === "object"
+      ? rawStoryStructure as { openingTitle?: string; introNarration?: string; chapters?: { title: string; description: string }[]; climaxDescription?: string; closingMessage?: string; dedicationText?: string }
+      : undefined;
+
     const userPrompt = buildStoryUserPrompt({
       locale: effectiveLocale,
       mode: effectiveMode,
@@ -254,6 +260,7 @@ export async function POST(req: Request) {
       captions: effectiveCaptions,
       exifSummary: effectiveExifSummary,
       targetDurationSeconds: effectiveTargetDurationSeconds,
+      storyStructure,
     });
 
     console.log(`[story/generate] Starting AI generation with ${effectiveCaptions.length} captions`);

--- a/apps/vionto/components/ViontoPage.tsx
+++ b/apps/vionto/components/ViontoPage.tsx
@@ -232,6 +232,26 @@ export function ViontoPage() {
   const [versions, setVersions] = useState<ScriptVersion[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
   const [userNotes, setUserNotes] = useState("");
+
+  // ─── Story structure state (#102) ──────────────────────────────────
+  const [storyStructureOpen, setStoryStructureOpen] = useState(false);
+  const [openingTitle, setOpeningTitle] = useState("");
+  const [introNarration, setIntroNarration] = useState("");
+  const [chapters, setChapters] = useState<{ title: string; description: string }[]>([]);
+  const [climaxDescription, setClimaxDescription] = useState("");
+  const [closingMessage, setClosingMessage] = useState("");
+  const [dedicationText, setDedicationText] = useState("");
+
+  // ─── Caption overlay state (#102) ──────────────────────────────────
+  const [captionOverlaysOpen, setCaptionOverlaysOpen] = useState(false);
+  const [captionsEnabled, setCaptionsEnabled] = useState(false);
+  const [showSceneCaptions, setShowSceneCaptions] = useState(true);
+  const [showDateCaptions, setShowDateCaptions] = useState(true);
+  const [showLocationCaptions, setShowLocationCaptions] = useState(true);
+  const [showPeopleLabels, setShowPeopleLabels] = useState(false);
+  const [captionPlacement, setCaptionPlacement] = useState<"top" | "bottom" | "lower_third" | "corner">("lower_third");
+  const [captionStylePreset, setCaptionStylePreset] = useState<"minimal" | "memory" | "social" | "documentary">("minimal");
+
   const [selectedStoryMode, setSelectedStoryMode] = useState<string>("memory_film");
   const [selectedEmotionalTone, setSelectedEmotionalTone] = useState<string>("nostalgic");
   const [selectedVisualStyle, setSelectedVisualStyle] = useState<VisualStyle>(DEFAULT_VISUAL_STYLE);
@@ -415,6 +435,23 @@ export function ViontoPage() {
     musicOption: string | null;
     aspectRatio: string;
     targetDurationSeconds: number | null;
+    storyStructure: {
+      openingTitle?: string;
+      introNarration?: string;
+      chapters?: { title: string; description: string }[];
+      climaxDescription?: string;
+      closingMessage?: string;
+      dedicationText?: string;
+    } | null;
+    captionOverlaySettings: {
+      enabled?: boolean;
+      showSceneCaptions?: boolean;
+      showDateCaptions?: boolean;
+      showLocationCaptions?: boolean;
+      showPeopleLabels?: boolean;
+      placement?: "top" | "bottom" | "lower_third" | "corner";
+      stylePreset?: "minimal" | "memory" | "social" | "documentary";
+    } | null;
     _count: { scripts: number; renderJobs: number; exports: number };
   };
   const [videoVersions, setVideoVersions] = useState<VideoVersion[]>([]);
@@ -471,6 +508,10 @@ export function ViontoPage() {
       setAlbumItems([]);
       setVideoVersions([]);
       setSelectedVersionId(null);
+      // Reset story structure & caption overlay state
+      setOpeningTitle(""); setIntroNarration(""); setChapters([]); setClimaxDescription(""); setClosingMessage(""); setDedicationText("");
+      setCaptionsEnabled(false); setShowSceneCaptions(true); setShowDateCaptions(true); setShowLocationCaptions(true); setShowPeopleLabels(false);
+      setCaptionPlacement("lower_third"); setCaptionStylePreset("minimal");
       loadExportLibrary();
     }
   }, [selectedProjectId, locale, projects]);
@@ -977,6 +1018,23 @@ export function ViontoPage() {
     setActiveAspectRatio(supportedAspect ? version.aspectRatio as AspectRatio : "16:9");
     setTargetDurationSeconds(version.targetDurationSeconds ?? 20);
     if (version.albumId) setSelectedAlbumId(version.albumId);
+    // Apply story structure (#102)
+    const ss = version.storyStructure;
+    setOpeningTitle(ss?.openingTitle ?? "");
+    setIntroNarration(ss?.introNarration ?? "");
+    setChapters(ss?.chapters ?? []);
+    setClimaxDescription(ss?.climaxDescription ?? "");
+    setClosingMessage(ss?.closingMessage ?? "");
+    setDedicationText(ss?.dedicationText ?? "");
+    // Apply caption overlay settings (#102)
+    const cos = version.captionOverlaySettings;
+    setCaptionsEnabled(cos?.enabled ?? false);
+    setShowSceneCaptions(cos?.showSceneCaptions ?? true);
+    setShowDateCaptions(cos?.showDateCaptions ?? true);
+    setShowLocationCaptions(cos?.showLocationCaptions ?? true);
+    setShowPeopleLabels(cos?.showPeopleLabels ?? false);
+    setCaptionPlacement(cos?.placement ?? "lower_third");
+    setCaptionStylePreset(cos?.stylePreset ?? "minimal");
     setScriptStale(false);
   }, [selectedVersionId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1077,6 +1135,17 @@ export function ViontoPage() {
   async function saveProjectSettings(): Promise<boolean> {
     if (!selectedProjectId) return false;
     const apiMode = UI_MODE_TO_API_MODE[activeMode] ?? "story";
+    // Gather story structure — only include if any field is non-empty
+    const storyStructure = {
+      openingTitle: openingTitle.trim(),
+      introNarration: introNarration.trim(),
+      chapters: chapters.filter((c) => c.title.trim() || c.description.trim()),
+      climaxDescription: climaxDescription.trim(),
+      closingMessage: closingMessage.trim(),
+      dedicationText: dedicationText.trim(),
+    };
+    const hasStoryStructure = storyStructure.openingTitle || storyStructure.introNarration || storyStructure.chapters.length > 0 || storyStructure.climaxDescription || storyStructure.closingMessage || storyStructure.dedicationText;
+
     const settingsData = {
       mode: apiMode,
       storyMode: selectedStoryMode,
@@ -1087,6 +1156,16 @@ export function ViontoPage() {
       musicMetadata: selectedMusicTracks.length > 0 ? selectedMusicTracks : null,
       aspectRatio: activeAspectRatio,
       targetDurationSeconds,
+      storyStructure: hasStoryStructure ? storyStructure : null,
+      captionOverlaySettings: {
+        enabled: captionsEnabled,
+        showSceneCaptions,
+        showDateCaptions,
+        showLocationCaptions,
+        showPeopleLabels,
+        placement: captionPlacement,
+        stylePreset: captionStylePreset,
+      },
     };
     try {
       // Save to the video version if one is selected (preferred).
@@ -3197,6 +3276,212 @@ export function ViontoPage() {
                   <p className="mt-1 rounded-md bg-amber-500/10 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-400">
                     {t("vionto.videoLength.staleWarning")}
                   </p>
+                )}
+              </div>
+
+              {/* ─── Story Structure (#102) ──────────────────────────── */}
+              <div className="mt-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+                <button
+                  type="button"
+                  onClick={() => setStoryStructureOpen(!storyStructureOpen)}
+                  className="flex w-full items-center justify-between px-3 py-2.5 text-left"
+                >
+                  <span className="flex items-center gap-1.5 text-xs font-medium text-[var(--color-text)]">
+                    <ListChecks size={14} className="text-[var(--color-accent)]" />
+                    Story Structure
+                  </span>
+                  {storyStructureOpen ? <ChevronUp size={14} className="text-[var(--color-text-muted)]" /> : <ChevronDown size={14} className="text-[var(--color-text-muted)]" />}
+                </button>
+                {storyStructureOpen && (
+                  <div className="space-y-2.5 border-t border-[var(--color-border)] px-3 pb-3 pt-2.5">
+                    <div>
+                      <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Opening Title</label>
+                      <input
+                        type="text"
+                        value={openingTitle}
+                        onChange={(e) => setOpeningTitle(e.target.value)}
+                        placeholder="e.g. Our Summer in Provence"
+                        maxLength={200}
+                        className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2.5 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Intro Narration</label>
+                      <textarea
+                        value={introNarration}
+                        onChange={(e) => setIntroNarration(e.target.value)}
+                        placeholder="A short intro paragraph to set the scene..."
+                        maxLength={1000}
+                        rows={2}
+                        className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2.5 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                      />
+                    </div>
+                    <div>
+                      <div className="flex items-center justify-between">
+                        <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Chapters</label>
+                        <button
+                          type="button"
+                          onClick={() => setChapters([...chapters, { title: "", description: "" }])}
+                          disabled={chapters.length >= 10}
+                          className="text-[11px] font-medium text-[var(--color-accent)] hover:underline disabled:opacity-50"
+                        >
+                          <Plus size={10} className="mr-0.5 inline" /> Add chapter
+                        </button>
+                      </div>
+                      {chapters.map((ch, i) => (
+                        <div key={i} className="mt-1 flex gap-1.5">
+                          <input
+                            type="text"
+                            value={ch.title}
+                            onChange={(e) => {
+                              const next = [...chapters];
+                              next[i] = { ...next[i], title: e.target.value };
+                              setChapters(next);
+                            }}
+                            placeholder={`Chapter ${i + 1} title`}
+                            maxLength={120}
+                            className="flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2 py-1 text-xs text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                          />
+                          <input
+                            type="text"
+                            value={ch.description}
+                            onChange={(e) => {
+                              const next = [...chapters];
+                              next[i] = { ...next[i], description: e.target.value };
+                              setChapters(next);
+                            }}
+                            placeholder="Description"
+                            maxLength={500}
+                            className="flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2 py-1 text-xs text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setChapters(chapters.filter((_, j) => j !== i))}
+                            className="shrink-0 rounded p-1 text-[var(--color-text-muted)] hover:text-red-500"
+                          >
+                            <X size={12} />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                    <div>
+                      <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Climax / Highlight</label>
+                      <input
+                        type="text"
+                        value={climaxDescription}
+                        onChange={(e) => setClimaxDescription(e.target.value)}
+                        placeholder="Which moment gets the most emphasis?"
+                        maxLength={500}
+                        className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2.5 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Closing Message</label>
+                      <input
+                        type="text"
+                        value={closingMessage}
+                        onChange={(e) => setClosingMessage(e.target.value)}
+                        placeholder="e.g. Until we meet again..."
+                        maxLength={500}
+                        className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2.5 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Dedication</label>
+                      <input
+                        type="text"
+                        value={dedicationText}
+                        onChange={(e) => setDedicationText(e.target.value)}
+                        placeholder="e.g. For Mom and Dad"
+                        maxLength={300}
+                        className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2.5 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* ─── Caption Overlays (#102) ──────────────────────────── */}
+              <div className="mt-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+                <button
+                  type="button"
+                  onClick={() => setCaptionOverlaysOpen(!captionOverlaysOpen)}
+                  className="flex w-full items-center justify-between px-3 py-2.5 text-left"
+                >
+                  <span className="flex items-center gap-1.5 text-xs font-medium text-[var(--color-text)]">
+                    <Captions size={14} className="text-[var(--color-accent)]" />
+                    Caption Overlays
+                    {captionsEnabled && (
+                      <span className="ml-1 rounded-full bg-[var(--color-accent)]/15 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--color-accent)]">ON</span>
+                    )}
+                  </span>
+                  {captionOverlaysOpen ? <ChevronUp size={14} className="text-[var(--color-text-muted)]" /> : <ChevronDown size={14} className="text-[var(--color-text-muted)]" />}
+                </button>
+                {captionOverlaysOpen && (
+                  <div className="space-y-3 border-t border-[var(--color-border)] px-3 pb-3 pt-2.5">
+                    <label className="flex items-center gap-2 text-sm text-[var(--color-text)]">
+                      <input
+                        type="checkbox"
+                        checked={captionsEnabled}
+                        onChange={(e) => setCaptionsEnabled(e.target.checked)}
+                        className="h-4 w-4 rounded border-[var(--color-border)] accent-[var(--color-accent)]"
+                      />
+                      Enable caption overlays
+                    </label>
+
+                    {captionsEnabled && (
+                      <>
+                        <div className="space-y-1.5">
+                          <p className="text-[11px] font-medium text-[var(--color-text-muted)]">Show in video</p>
+                          {[
+                            { label: "Scene captions", checked: showSceneCaptions, onChange: setShowSceneCaptions },
+                            { label: "Date captions", checked: showDateCaptions, onChange: setShowDateCaptions },
+                            { label: "Location captions", checked: showLocationCaptions, onChange: setShowLocationCaptions },
+                            { label: "People labels", checked: showPeopleLabels, onChange: setShowPeopleLabels },
+                          ].map((item) => (
+                            <label key={item.label} className="flex items-center gap-2 text-xs text-[var(--color-text)]">
+                              <input
+                                type="checkbox"
+                                checked={item.checked}
+                                onChange={(e) => item.onChange(e.target.checked)}
+                                className="h-3.5 w-3.5 rounded border-[var(--color-border)] accent-[var(--color-accent)]"
+                              />
+                              {item.label}
+                            </label>
+                          ))}
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-2">
+                          <div>
+                            <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Placement</label>
+                            <select
+                              value={captionPlacement}
+                              onChange={(e) => setCaptionPlacement(e.target.value as any)}
+                              className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2 py-1.5 text-xs text-[var(--color-text)]"
+                            >
+                              <option value="lower_third">Lower third</option>
+                              <option value="top">Top</option>
+                              <option value="bottom">Bottom</option>
+                              <option value="corner">Corner</option>
+                            </select>
+                          </div>
+                          <div>
+                            <label className="text-[11px] font-medium text-[var(--color-text-muted)]">Style</label>
+                            <select
+                              value={captionStylePreset}
+                              onChange={(e) => setCaptionStylePreset(e.target.value as any)}
+                              className="mt-0.5 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2 py-1.5 text-xs text-[var(--color-text)]"
+                            >
+                              <option value="minimal">Minimal</option>
+                              <option value="memory">Memory</option>
+                              <option value="social">Social</option>
+                              <option value="documentary">Documentary</option>
+                            </select>
+                          </div>
+                        </div>
+                      </>
+                    )}
+                  </div>
                 )}
               </div>
 

--- a/apps/vionto/lib/server/render-manifest.ts
+++ b/apps/vionto/lib/server/render-manifest.ts
@@ -122,6 +122,35 @@ export const renderManifestSchema = z.object({
   subtitleExport: subtitleExportSchema.default({}),
   subtitlePresetId: z.string().optional(),
 
+  // Story structure & caption overlays (#102)
+  storyStructure: z.object({
+    openingTitle: z.string().default(""),
+    introNarration: z.string().default(""),
+    chapters: z.array(z.object({
+      title: z.string().default(""),
+      description: z.string().default(""),
+    })).default([]),
+    climaxDescription: z.string().default(""),
+    closingMessage: z.string().default(""),
+    dedicationText: z.string().default(""),
+  }).optional(),
+  captionOverlays: z.array(z.object({
+    assetIndex: z.number().int().min(0).optional(),
+    startSeconds: z.number().min(0),
+    endSeconds: z.number().min(0),
+    text: z.string(),
+    kind: z.enum(["scene", "date", "location", "person"]),
+  })).optional(),
+  captionOverlaySettings: z.object({
+    enabled: z.boolean().default(false),
+    showSceneCaptions: z.boolean().default(true),
+    showDateCaptions: z.boolean().default(true),
+    showLocationCaptions: z.boolean().default(true),
+    showPeopleLabels: z.boolean().default(false),
+    placement: z.enum(["top", "bottom", "lower_third", "corner"]).default("lower_third"),
+    stylePreset: z.enum(["minimal", "memory", "social", "documentary"]).default("minimal"),
+  }).optional(),
+
   outputFormat: z.enum(["mp4", "mov", "webm"]).default("mp4"),
   videoCodec: z.enum(["libx264", "libx265"]).default("libx264"),
   audioCodec: z.enum(["aac", "libmp3lame"]).default("aac"),
@@ -143,6 +172,7 @@ export type SubtitleTiming = z.infer<typeof subtitleTimingSchema>;
 export type SubtitleExport = z.infer<typeof subtitleExportSchema>;
 export type SubtitleConfig = z.infer<typeof subtitleConfigSchema>;
 export type VisualStyle = z.infer<typeof visualStyleSchema>;
+export type CaptionOverlay = NonNullable<RenderManifest["captionOverlays"]>[number];
 
 /** Validate and parse a raw manifest payload. */
 export function parseManifest(payload: unknown): RenderManifest {

--- a/apps/vionto/lib/server/story-generation.ts
+++ b/apps/vionto/lib/server/story-generation.ts
@@ -179,6 +179,15 @@ export async function generateWithAnthropic(
   };
 }
 
+export type StoryStructureContext = {
+  openingTitle?: string;
+  introNarration?: string;
+  chapters?: { title: string; description: string }[];
+  climaxDescription?: string;
+  closingMessage?: string;
+  dedicationText?: string;
+};
+
 export type StoryPromptContext = {
   locale: string;
   mode: "story" | "slideshow" | "documentary";
@@ -190,6 +199,8 @@ export type StoryPromptContext = {
   exifSummary?: string;
   /** Target video duration in seconds (10–90, multiple of 5). Drives narration length. */
   targetDurationSeconds?: number;
+  /** Optional story structure with opening title, chapters, climax, etc. */
+  storyStructure?: StoryStructureContext;
 };
 
 export function buildStorySystemPrompt(locale: string): string {
@@ -218,6 +229,30 @@ export function buildStoryUserPrompt(ctx: StoryPromptContext): string {
   if (ctx.exifSummary && ctx.exifSummary.trim()) {
     lines.push(`Photo metadata: ${ctx.exifSummary.trim()}`);
   }
+
+  // Story structure — give the LLM explicit narrative skeleton when provided.
+  const ss = ctx.storyStructure;
+  if (ss) {
+    const structureLines: string[] = [];
+    if (ss.openingTitle) structureLines.push(`Opening title: "${ss.openingTitle}"`);
+    if (ss.introNarration) structureLines.push(`Intro narration: ${ss.introNarration}`);
+    if (ss.chapters && ss.chapters.length > 0) {
+      const chapStr = ss.chapters
+        .filter((c) => c.title || c.description)
+        .map((c, i) => `Chapter ${i + 1}${c.title ? `: ${c.title}` : ""}${c.description ? ` — ${c.description}` : ""}`)
+        .join("; ");
+      if (chapStr) structureLines.push(`Chapters: ${chapStr}`);
+    }
+    if (ss.climaxDescription) structureLines.push(`Climax/highlight: ${ss.climaxDescription}`);
+    if (ss.closingMessage) structureLines.push(`Closing message: "${ss.closingMessage}"`);
+    if (ss.dedicationText) structureLines.push(`Dedication: "${ss.dedicationText}"`);
+    if (structureLines.length > 0) {
+      lines.push("");
+      lines.push("Story structure provided by the user:");
+      structureLines.forEach((l) => lines.push(`- ${l}`));
+    }
+  }
+
   lines.push("");
   lines.push("Instructions:");
   
@@ -278,6 +313,18 @@ export function buildStoryUserPrompt(ctx: StoryPromptContext): string {
     lines.push("- Favor elegant, intimate phrasing that works with a cinematic wedding treatment.");
   }
   
+  // Story structure instructions
+  if (ss) {
+    const hasContent = ss.openingTitle || ss.introNarration || (ss.chapters && ss.chapters.length > 0) || ss.climaxDescription || ss.closingMessage || ss.dedicationText;
+    if (hasContent) {
+      lines.push("- Follow the user's story structure. Incorporate the opening title, chapter flow, climax, closing, and dedication into the narration naturally.");
+      if (ss.openingTitle) lines.push(`- Start the narration by referencing or incorporating the opening title: "${ss.openingTitle}".`);
+      if (ss.closingMessage) lines.push(`- End the narration with the closing message: "${ss.closingMessage}".`);
+      if (ss.dedicationText) lines.push(`- Include a brief dedication at the very end: "${ss.dedicationText}".`);
+      lines.push("- If a field is empty, skip it naturally — do not create placeholder content for missing fields.");
+    }
+  }
+
   // Duration-aware narration and SRT instructions
   const targetSec = ctx.targetDurationSeconds ?? 30;
   const approxWords = Math.round(targetSec * 2.5); // ~150 wpm speaking rate

--- a/apps/vionto/lib/server/validation.ts
+++ b/apps/vionto/lib/server/validation.ts
@@ -129,6 +129,42 @@ export const createProjectSchema = z.object({
 
 export const updateProjectSchema = createProjectSchema.partial();
 
+// ─── Story structure & caption overlay schemas (#102) ────────────────
+
+/** Chapter entry for a video's narrative structure. */
+const storyChapterSchema = z.object({
+  title: z.string().max(120).default(""),
+  description: z.string().max(500).default(""),
+});
+
+/** Story structure defines the narrative skeleton of a generated video. */
+export const storyStructureSchema = z.object({
+  openingTitle: z.string().max(200).default(""),
+  introNarration: z.string().max(1000).default(""),
+  chapters: z.array(storyChapterSchema).max(10).default([]),
+  climaxDescription: z.string().max(500).default(""),
+  closingMessage: z.string().max(500).default(""),
+  dedicationText: z.string().max(300).default(""),
+});
+
+export type StoryStructure = z.infer<typeof storyStructureSchema>;
+
+const CAPTION_PLACEMENTS = ["top", "bottom", "lower_third", "corner"] as const;
+const CAPTION_STYLE_PRESETS = ["minimal", "memory", "social", "documentary"] as const;
+
+/** Caption overlay settings control which metadata captions appear in the rendered video. */
+export const captionOverlaySettingsSchema = z.object({
+  enabled: z.boolean().default(false),
+  showSceneCaptions: z.boolean().default(true),
+  showDateCaptions: z.boolean().default(true),
+  showLocationCaptions: z.boolean().default(true),
+  showPeopleLabels: z.boolean().default(false),
+  placement: z.enum(CAPTION_PLACEMENTS).default("lower_third"),
+  stylePreset: z.enum(CAPTION_STYLE_PRESETS).default("minimal"),
+});
+
+export type CaptionOverlaySettings = z.infer<typeof captionOverlaySettingsSchema>;
+
 // ─── Video version schemas ──────────────────────────────────────────
 
 const musicOptionValues = ["calm_piano", "cinematic_strings", "travel_upbeat", "family_warm_acoustic", "no_music", "upload_own"] as const;
@@ -148,6 +184,8 @@ export const createVideoVersionSchema = z.object({
   aspectRatio: z.enum(["16:9", "9:16", "1:1", "4:3"]).default("16:9"),
   resolution: z.enum(["720p", "1080p", "4k"]).nullable().optional(),
   targetDurationSeconds: targetDurationSecondsSchema.optional(),
+  storyStructure: storyStructureSchema.nullable().optional(),
+  captionOverlaySettings: captionOverlaySettingsSchema.nullable().optional(),
   /** Clone settings from an existing version instead of using defaults. */
   cloneFromVersionId: z.string().cuid().optional(),
 });

--- a/packages/db/prisma/migrations/20260523120000_add_story_structure_caption_overlays/migration.sql
+++ b/packages/db/prisma/migrations/20260523120000_add_story_structure_caption_overlays/migration.sql
@@ -1,0 +1,6 @@
+-- Add story structure and caption overlay settings to ViontoVideoVersion
+-- These are JSON columns storing structured settings per video version.
+
+ALTER TABLE "ViontoVideoVersion"
+  ADD COLUMN "storyStructure" JSONB,
+  ADD COLUMN "captionOverlaySettings" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1632,6 +1632,12 @@ model ViontoVideoVersion {
   resolution            String? // 720p, 1080p, 4k; null = auto
   targetDurationSeconds Int?
 
+  // ── Story structure & caption overlays (#102) ──
+  /// Narrative structure: opening title, chapters, climax, closing, dedication.
+  storyStructure         Json?
+  /// Caption overlay toggles: scene/date/location/people, placement, style.
+  captionOverlaySettings Json?
+
   // ── Relations ──
   project     ViontoProject      @relation(fields: [projectId], references: [id], onDelete: Cascade)
   album       ViontoAlbum?       @relation(fields: [albumId], references: [id], onDelete: SetNull)


### PR DESCRIPTION
## Summary

- Combines **#71** (caption overlays) and **#72** (story structure controls) into a single feature (**#102**)
- Adds story structure fields (opening title, chapters, climax, closing message, dedication) that feed into the AI story generation prompt
- Adds caption overlay settings (scene/date/location/people toggles, placement, style preset) persisted per video version
- Both features use the `ViontoVideoVersion` model from #73, making settings per-version

## Changes

### Schema & Migration
- `storyStructure` (JSON) and `captionOverlaySettings` (JSON) columns on `ViontoVideoVersion`
- Migration: `20260523120000_add_story_structure_caption_overlays`

### Validation (Zod)
- `storyStructureSchema`: opening title, intro narration, chapters array, climax, closing, dedication
- `captionOverlaySettingsSchema`: enabled flag, show toggles, placement, style preset
- Both added to `createVideoVersionSchema` / `updateVideoVersionSchema`

### Story Generation
- `StoryPromptContext` extended with `storyStructure`
- Prompt builder injects structure fields as narrative skeleton for the LLM
- Structure-aware instructions: incorporate title, follow chapter flow, include dedication
- Empty fields are skipped naturally (no placeholder content)

### Render Manifest
- `storyStructure`, `captionOverlays`, and `captionOverlaySettings` added to manifest schema
- Render route passes both settings from the version into the manifest

### API Routes
- Version routes (`GET`, `POST`, `PATCH`) select and persist the new fields
- Clone (duplicate) copies story structure and caption settings
- Prisma `JsonNull` handling for nullable JSON columns

### UI (ViontoPage.tsx)
- **Story Structure panel**: collapsible section with fields for opening title, intro narration, dynamic chapter list (add/remove), climax/highlight, closing message, dedication
- **Caption Overlays panel**: collapsible section with enable toggle, show checkboxes (scene, date, location, people), placement dropdown, style preset dropdown
- State loads from selected version, resets on project change
- Settings saved via version PATCH endpoint (syncs to project for backward compat)

## Test plan
- [ ] Create a project, select a version, open Story Structure panel
- [ ] Fill in opening title, add chapters, set closing message
- [ ] Generate a story — verify the narration references the title, follows chapters, includes closing
- [ ] Toggle Caption Overlays on, select placement and style
- [ ] Switch versions — verify settings load correctly per version
- [ ] Duplicate a version — verify story structure and caption settings are cloned
- [ ] Verify TypeScript compiles clean (0 errors confirmed)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #103