### PR TITLE
fix(vionto): make album selection version-owned

### DIFF
--- a/apps/vionto/components/ViontoPage.tsx
+++ b/apps/vionto/components/ViontoPage.tsx
@@ -2906,21 +2906,6 @@ export function ViontoPage() {
                               {isSorting ? <RefreshCw size={12} className="animate-spin" /> : <MapPin size={12} />}
                               Group by location
                             </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                const albumVersions = videoVersions.filter((v) => v.albumId === selectedAlbumId);
-                                createVideoVersion(
-                                  `${selectedAlbum?.name} - Version ${albumVersions.length + 1}`,
-                                  selectedAlbumId,
-                                );
-                              }}
-                              className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-soft)] px-2 py-1 text-xs font-medium text-[var(--color-text)] hover:border-[var(--color-accent)] transition-colors"
-                              title="Create a new video version linked to this album"
-                            >
-                              <Clapperboard size={12} />
-                              New version
-                            </button>
                           </div>
                         </div>
                       )}
@@ -3029,10 +3014,12 @@ export function ViontoPage() {
                       {/* Linked video versions for this album */}
                       {selectedAlbum && !isBaseAlbumSelected && (() => {
                         const albumVersions = videoVersions.filter((v) => v.albumId === selectedAlbumId);
-                        if (albumVersions.length === 0) return null;
                         return (
                           <div className="mb-2 flex items-center gap-1.5 flex-wrap">
-                            <span className="text-[10px] font-medium text-[var(--color-text-muted)]">Versions:</span>
+                            <span className="text-[10px] font-medium text-[var(--color-text-muted)]">Video versions using this album:</span>
+                            {albumVersions.length === 0 && (
+                              <span className="text-[10px] text-[var(--color-text-muted)] italic">None yet</span>
+                            )}
                             {albumVersions.map((v) => (
                               <button
                                 key={v.id}
@@ -3048,6 +3035,21 @@ export function ViontoPage() {
                                 {v.name}
                               </button>
                             ))}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                if (!confirm(`Create a new video version linked to "${selectedAlbum.name}"?\n\nThis adds a new entry in the Video Version tabs above — it is separate from the album itself.`)) return;
+                                createVideoVersion(
+                                  `${selectedAlbum.name} - Version ${albumVersions.length + 1}`,
+                                  selectedAlbumId,
+                                );
+                              }}
+                              className="inline-flex items-center gap-1 rounded-md border border-dashed border-[var(--color-border)] px-2 py-0.5 text-[10px] font-medium text-[var(--color-text-muted)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition-colors"
+                              title="Create a brand-new video version linked to this album"
+                            >
+                              <Plus size={9} />
+                              New video version
+                            </button>
                           </div>
                         );
                       })()}

--- a/apps/vionto/components/ViontoPage.tsx
+++ b/apps/vionto/components/ViontoPage.tsx
@@ -477,6 +477,7 @@ export function ViontoPage() {
   };
   const [videoVersions, setVideoVersions] = useState<VideoVersion[]>([]);
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
+  const lastAppliedVersionId = useRef<string | null>(null);
   const [isLoadingVersions, setIsLoadingVersions] = useState(false);
   const [renamingVersionId, setRenamingVersionId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
@@ -711,7 +712,7 @@ export function ViontoPage() {
       setNewAlbumCollections([]);
       setNewAlbumFavorite(false);
       await loadProjectAlbums(selectedProjectId);
-      setSelectedAlbumId(created.id);
+      await selectAlbumForActiveVersion(created.id);
     } catch (error) {
       console.error("Failed to create album", error);
       alert("Failed to create album");
@@ -969,9 +970,41 @@ export function ViontoPage() {
   }
 
   const selectedAlbum = albums.find((a) => a.id === selectedAlbumId) ?? null;
+  const activeVersion = videoVersions.find((v) => v.id === selectedVersionId) ?? null;
+  const activeVersionAlbumId = activeVersion?.albumId ?? albums.find((album) => album.isBase)?.id ?? albums[0]?.id ?? null;
   const isBaseAlbumSelected = selectedAlbum?.isBase ?? true;
   const metaEditorItem = albumItems.find((i) => i.id === metaEditorItemId) ?? null;
   const metaEditorAssetUrl = metaEditorItem?.asset.thumbnailUrl ?? metaEditorItem?.asset.originalUrl ?? null;
+
+  async function selectAlbumForActiveVersion(albumId: string) {
+    setSelectedAlbumId(albumId);
+
+    if (!selectedProjectId || !selectedVersionId) return;
+    const previousAlbumId = activeVersion?.albumId ?? null;
+    if (previousAlbumId === albumId) return;
+
+    try {
+      const res = await fetch(`/api/projects/${selectedProjectId}/versions/${selectedVersionId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ albumId }),
+      });
+      if (!res.ok) {
+        const message = await res.text().catch(() => "");
+        throw new Error(message || "Failed to link album to version");
+      }
+      setVideoVersions((prev) =>
+        prev.map((version) =>
+          version.id === selectedVersionId ? { ...version, albumId } : version
+        )
+      );
+      setScriptStale(true);
+    } catch (error) {
+      console.error("Failed to link album to version", error);
+      setSelectedAlbumId(previousAlbumId ?? activeVersionAlbumId);
+      alert("Could not link this album to the active version.");
+    }
+  }
 
   // ─── End album management functions ────────────────────────────────────────
 
@@ -1081,33 +1114,46 @@ export function ViontoPage() {
     if (!selectedVersionId) return;
     const version = videoVersions.find((v) => v.id === selectedVersionId);
     if (!version) return;
-    setActiveMode(API_MODE_TO_UI_MODE[version.mode] ?? "cinematic");
-    setSelectedStoryMode(version.storyMode ?? "memory_film");
-    setSelectedEmotionalTone(version.emotionalTone ?? "nostalgic");
-    setSelectedVisualStyle(normalizeVisualStyle(version.visualStyle));
-    const supportedAspect = ASPECT_OPTIONS.some((o) => o.value === version.aspectRatio);
-    setActiveAspectRatio(supportedAspect ? version.aspectRatio as AspectRatio : "16:9");
-    setTargetDurationSeconds(version.targetDurationSeconds ?? 20);
-    if (version.albumId) setSelectedAlbumId(version.albumId);
-    // Apply story structure (#102)
-    const ss = version.storyStructure;
-    setOpeningTitle(ss?.openingTitle ?? "");
-    setIntroNarration(ss?.introNarration ?? "");
-    setChapters(ss?.chapters ?? []);
-    setClimaxDescription(ss?.climaxDescription ?? "");
-    setClosingMessage(ss?.closingMessage ?? "");
-    setDedicationText(ss?.dedicationText ?? "");
-    // Apply caption overlay settings (#102)
-    const cos = version.captionOverlaySettings;
-    setCaptionsEnabled(cos?.enabled ?? false);
-    setShowSceneCaptions(cos?.showSceneCaptions ?? true);
-    setShowDateCaptions(cos?.showDateCaptions ?? true);
-    setShowLocationCaptions(cos?.showLocationCaptions ?? true);
-    setShowPeopleLabels(cos?.showPeopleLabels ?? false);
-    setCaptionPlacement(cos?.placement ?? "lower_third");
-    setCaptionStylePreset(cos?.stylePreset ?? "minimal");
-    setScriptStale(false);
-  }, [selectedVersionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const shouldApplySettings = lastAppliedVersionId.current !== selectedVersionId;
+    if (shouldApplySettings) {
+      setActiveMode(API_MODE_TO_UI_MODE[version.mode] ?? "cinematic");
+      setSelectedStoryMode(version.storyMode ?? "memory_film");
+      setSelectedEmotionalTone(version.emotionalTone ?? "nostalgic");
+      setSelectedVisualStyle(normalizeVisualStyle(version.visualStyle));
+      const supportedAspect = ASPECT_OPTIONS.some((o) => o.value === version.aspectRatio);
+      setActiveAspectRatio(supportedAspect ? version.aspectRatio as AspectRatio : "16:9");
+      setTargetDurationSeconds(version.targetDurationSeconds ?? 20);
+    }
+    setSelectedAlbumId(
+      version.albumId ??
+      albums.find((album) => album.isBase)?.id ??
+      albums[0]?.id ??
+      null
+    );
+
+    if (shouldApplySettings) {
+      // Apply story structure (#102)
+      const ss = version.storyStructure;
+      setOpeningTitle(ss?.openingTitle ?? "");
+      setIntroNarration(ss?.introNarration ?? "");
+      setChapters(ss?.chapters ?? []);
+      setClimaxDescription(ss?.climaxDescription ?? "");
+      setClosingMessage(ss?.closingMessage ?? "");
+      setDedicationText(ss?.dedicationText ?? "");
+      // Apply caption overlay settings (#102)
+      const cos = version.captionOverlaySettings;
+      setCaptionsEnabled(cos?.enabled ?? false);
+      setShowSceneCaptions(cos?.showSceneCaptions ?? true);
+      setShowDateCaptions(cos?.showDateCaptions ?? true);
+      setShowLocationCaptions(cos?.showLocationCaptions ?? true);
+      setShowPeopleLabels(cos?.showPeopleLabels ?? false);
+      setCaptionPlacement(cos?.placement ?? "lower_third");
+      setCaptionStylePreset(cos?.stylePreset ?? "minimal");
+      setScriptStale(false);
+      lastAppliedVersionId.current = selectedVersionId;
+    }
+  }, [selectedVersionId, videoVersions, albums]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ─── End video version management functions ─────────────────────────────
 
@@ -1250,7 +1296,7 @@ export function ViontoPage() {
         const res = await fetch(`/api/projects/${selectedProjectId}/versions/${selectedVersionId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(settingsData),
+          body: JSON.stringify({ ...settingsData, albumId: selectedAlbumId ?? null }),
         });
         if (!res.ok) {
           const message = await res.text().catch(() => "");
@@ -1440,7 +1486,7 @@ export function ViontoPage() {
         body: JSON.stringify({
           projectId: selectedProjectId,
           versionId: selectedVersionId ?? undefined,
-          albumId: selectedAlbumId ?? undefined,
+          ...(!selectedVersionId && selectedAlbumId ? { albumId: selectedAlbumId } : {}),
         }),
       });
       if (!res.ok) {
@@ -1799,7 +1845,7 @@ export function ViontoPage() {
         body: JSON.stringify({
           projectId: selectedProjectId,
           versionId: selectedVersionId ?? undefined,
-          albumId: selectedAlbumId ?? undefined,
+          ...(!selectedVersionId && selectedAlbumId ? { albumId: selectedAlbumId } : {}),
           locale: locale.split("-")[0] ?? "en",
           mode: apiMode,
           visualStyle: selectedVisualStyle,
@@ -2573,7 +2619,14 @@ export function ViontoPage() {
                 <div className="mt-4" aria-label="Album management">
                   {/* Album selector bar */}
                   <div className="flex items-center justify-between gap-2">
-                    <p className="text-xs font-medium text-[var(--color-text-muted)]">Albums</p>
+                    <div>
+                      <p className="text-xs font-medium text-[var(--color-text-muted)]">Album for active version</p>
+                      {activeVersion && (
+                        <p className="text-[10px] text-[var(--color-text-muted)]">
+                          {activeVersion.name} renders from {selectedAlbum?.name ?? "the selected album"}.
+                        </p>
+                      )}
+                    </div>
                     <div className="flex items-center gap-1.5">
                       <select
                         value={albumCollectionFilter}
@@ -2619,7 +2672,7 @@ export function ViontoPage() {
                           ) : (
                             <button
                               type="button"
-                              onClick={() => setSelectedAlbumId(album.id)}
+                              onClick={() => selectAlbumForActiveVersion(album.id)}
                               onDoubleClick={() => {
                                 if (!album.isBase) {
                                   setRenamingAlbumId(album.id);
@@ -2638,6 +2691,11 @@ export function ViontoPage() {
                               {!album.isBase && album.privacyLevel === "public" && <Globe size={9} className="opacity-50" />}
                               {album.isFavorite && <span className="text-[10px] text-[var(--color-accent)]">★</span>}
                               {album.name}
+                              {album.id === activeVersionAlbumId && (
+                                <span className="rounded bg-[var(--color-accent)]/10 px-1 text-[9px] text-[var(--color-accent)]">
+                                  linked
+                                </span>
+                              )}
                               <span className="rounded bg-[var(--color-accent)]/10 px-1 text-[9px] text-[var(--color-accent)]">
                                 {LIFECYCLE_LABELS[album.lifecycleStage]?.label ?? album.lifecycleStage}
                               </span>


### PR DESCRIPTION
## Summary
Implements the album/version relationship model from #107.

- Treats the selected version as the owner of the active album selection.
- Persists album clicks to `ViontoVideoVersion.albumId` through the existing version PATCH endpoint.
- Saves `albumId` with version settings so the version remains coherent after edits.
- Lets story generation and rendering use the persisted version album when `versionId` is present, instead of sending a transient album override.
- Falls back to the base album when a version has no album yet, avoiding stale album selection from a previous version.
- Updates the album selector copy and badges to show the album linked to the active version.

## Validation
- `pnpm --filter vionto typecheck`
- Browser smoke check at `http://localhost:3006/create` confirmed the page loads and the create form renders.

Closes #107

Refs #108