### PR TITLE
Fix EduMatch release verification baseline

### DIFF
--- a/apps/edumatch/__tests__/api/inquiries.test.ts
+++ b/apps/edumatch/__tests__/api/inquiries.test.ts
@@ -1,58 +1,123 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createMocks } from 'node-mocks-http';
-import { prisma } from '@asafarim/db';
-import { POST as createInquiry } from '@/app/api/inquiries/route';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
 
-describe('Inquiries API', () => {
-  beforeAll(async () => {
-    // Seed test data
+vi.mock("@/lib/server/profiles", () => ({
+  requireStudent: vi.fn(),
+}));
+
+vi.mock("@/lib/server", () => ({
+  handleEduError: vi.fn((_scope: string, error: Error) =>
+    NextResponse.json({ error: error.message }, { status: 401 }),
+  ),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  badRequest: vi.fn((message: string) =>
+    NextResponse.json({ error: message }, { status: 400 }),
+  ),
+  serverError: vi.fn((_scope: string, error: unknown) =>
+    NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    ),
+  ),
+}));
+
+vi.mock("@/lib/server/inquiries", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/server/inquiries")>(
+    "@/lib/server/inquiries",
+  );
+  return {
+    InquiryValidationError: actual.InquiryValidationError,
+    createInquiry: vi.fn(),
+    listInquiriesForStudent: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/ai-orchestrator", () => ({
+  orchestrateResponse: vi.fn(() => Promise.resolve()),
+}));
+
+import { POST as createInquiryRoute } from "@/app/api/inquiries/route";
+import { requireStudent } from "@/lib/server/profiles";
+import { createInquiry } from "@/lib/server/inquiries";
+import { orchestrateResponse } from "@/lib/server/ai-orchestrator";
+
+function jsonRequest(body: unknown): Request {
+  return new Request("http://localhost:3005/api/inquiries", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
   });
+}
 
-  afterAll(async () => {
-    await prisma.$disconnect();
-  });
+beforeEach(() => {
+  vi.mocked(requireStudent).mockReset();
+  vi.mocked(createInquiry).mockReset();
+  vi.mocked(orchestrateResponse).mockClear();
+});
 
-  it('should create an inquiry with valid data', async () => {
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: {
-        subject: 'Mathematics',
-        gradeLevel: 'K12',
-        description: 'Help with algebra',
-      },
-    });
+describe("Inquiries API", () => {
+  it("creates an inquiry with valid data", async () => {
+    vi.mocked(requireStudent).mockResolvedValue({
+      user: { id: "student-1", email: "student@example.com", tenantId: null, roles: [] },
+      profile: { userId: "student-1" },
+    } as never);
+    vi.mocked(createInquiry).mockResolvedValue({ id: "inq-1", status: "NEW" });
 
-    // Mock auth
-    req.auth = { userId: 'test-user-id', role: 'student' };
+    const response = await createInquiryRoute(
+      jsonRequest({
+        subject: "Mathematics",
+        gradeLevel: "K12",
+        description: "Help with algebra equations",
+      }),
+    );
 
-    const response = await createInquiry(req as any);
     expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ id: "inq-1", status: "NEW" });
+    expect(createInquiry).toHaveBeenCalledWith(
+      "student-1",
+      expect.objectContaining({
+        subject: "Mathematics",
+        gradeLevel: "K12",
+        description: "Help with algebra equations",
+        attachments: [],
+      }),
+    );
+    expect(orchestrateResponse).toHaveBeenCalledWith("inq-1");
   });
 
-  it('should return 400 for missing subject', async () => {
-    const { req } = createMocks({
-      method: 'POST',
-      body: {
-        gradeLevel: 'K12',
-        description: 'Help with algebra',
-      },
-    });
+  it("returns 400 for missing subject", async () => {
+    vi.mocked(requireStudent).mockResolvedValue({
+      user: { id: "student-1", email: "student@example.com", tenantId: null, roles: [] },
+      profile: { userId: "student-1" },
+    } as never);
 
-    const response = await createInquiry(req as any);
+    const response = await createInquiryRoute(
+      jsonRequest({
+        gradeLevel: "K12",
+        description: "Help with algebra",
+      }),
+    );
+
     expect(response.status).toBe(400);
+    expect(createInquiry).not.toHaveBeenCalled();
   });
 
-  it('should return 401 for unauthenticated users', async () => {
-    const { req } = createMocks({
-      method: 'POST',
-      body: {
-        subject: 'Mathematics',
-        gradeLevel: 'K12',
-        description: 'Help',
-      },
-    });
+  it("returns 401 for unauthenticated users", async () => {
+    const error = new Error("Unauthorized");
+    error.name = "EduAuthError";
+    vi.mocked(requireStudent).mockRejectedValue(error);
 
-    const response = await createInquiry(req as any);
+    const response = await createInquiryRoute(
+      jsonRequest({
+        subject: "Mathematics",
+        gradeLevel: "K12",
+        description: "Help with algebra equations",
+      }),
+    );
+
     expect(response.status).toBe(401);
+    expect(createInquiry).not.toHaveBeenCalled();
   });
 });

--- a/apps/edumatch/components/EduNav.tsx
+++ b/apps/edumatch/components/EduNav.tsx
@@ -336,7 +336,8 @@ function EduLogo() {
 
 /**
  * Controls that are always pinned in the navbar bar at every breakpoint.
- * Language selector + theme toggle are small enough to always stay visible.
+ * Language selector stays visible; theme is supplied through AppNavbar's
+ * dedicated themeToggler slot.
  */
 function CompactControls() {
   return (
@@ -344,7 +345,6 @@ function CompactControls() {
       {/* Show flag+lang on sm+, flag-only on xs */}
       <CountryLanguageSelector compact={false} className="hidden sm:block" />
       <CountryLanguageSelector compact={true} className="sm:hidden" />
-      <ThemeToggle />
     </>
   );
 }

--- a/apps/edumatch/lib/server/__tests__/profiles.test.ts
+++ b/apps/edumatch/lib/server/__tests__/profiles.test.ts
@@ -18,6 +18,8 @@ vi.mock("@asafarim/db", () => ({
   prisma: {
     eduStudentProfile: { findUnique: vi.fn() },
     eduTutorProfile: { findUnique: vi.fn() },
+    role: { findUnique: vi.fn() },
+    userRole: { upsert: vi.fn() },
   },
 }));
 
@@ -39,6 +41,9 @@ const tutorProfile = { userId: "u-tutor" } as never;
 beforeEach(() => {
   vi.mocked(prisma.eduStudentProfile.findUnique).mockReset();
   vi.mocked(prisma.eduTutorProfile.findUnique).mockReset();
+  vi.mocked(prisma.role.findUnique).mockReset();
+  vi.mocked(prisma.userRole.upsert).mockReset();
+  vi.mocked(prisma.role.findUnique).mockResolvedValue(null);
   vi.mocked(getAuthedUser).mockReset();
 });
 

--- a/apps/edumatch/lib/server/__tests__/tutor-matching.test.ts
+++ b/apps/edumatch/lib/server/__tests__/tutor-matching.test.ts
@@ -11,8 +11,11 @@ import { prisma } from "@asafarim/db";
 // Mock Prisma
 vi.mock("@asafarim/db", () => ({
   prisma: {
-    $queryRaw: vi.fn(),
-    $executeRaw: vi.fn(),
+    eduTutorProfile: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
   },
 }));
 
@@ -34,11 +37,12 @@ describe("findNearbyTutors", () => {
         ratingAvg: 4.8,
         ratingCount: 12,
         verifiedAt: new Date(),
-        distanceMeters: 5000,
+        homeLat: 51.552366140432586,
+        homeLng: -0.1278,
       },
     ];
 
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce(mockResults);
+    vi.mocked(prisma.eduTutorProfile.findMany).mockResolvedValueOnce(mockResults as never);
 
     const result = await findNearbyTutors({
       studentLocation: { lat: 51.5074, lng: -0.1278 }, // London
@@ -54,7 +58,7 @@ describe("findNearbyTutors", () => {
   });
 
   it("returns empty array when no tutors found", async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([]);
+    vi.mocked(prisma.eduTutorProfile.findMany).mockResolvedValueOnce([]);
 
     const result = await findNearbyTutors({
       studentLocation: { lat: 0, lng: 0 },
@@ -67,9 +71,13 @@ describe("findNearbyTutors", () => {
   });
 
   it("converts distance from meters to km with precision", async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
-      { ...mockTutor(), distanceMeters: 12345 },
-    ]);
+    vi.mocked(prisma.eduTutorProfile.findMany).mockResolvedValueOnce([
+      {
+        ...mockTutor(),
+        homeLat: 40.82380717154044,
+        homeLng: -74.006,
+      },
+    ] as never);
 
     const result = await findNearbyTutors({
       studentLocation: { lat: 40.7128, lng: -74.006 }, // NYC
@@ -192,7 +200,12 @@ describe("scoreTutors", () => {
 
 describe("canTutorServiceLocation", () => {
   it("returns true when student is within tutor's service radius", async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ withinRadius: true }]);
+    vi.mocked(prisma.eduTutorProfile.findUnique).mockResolvedValueOnce({
+      onlineOnly: false,
+      serviceRadiusKm: 25,
+      homeLat: 51.5074,
+      homeLng: -0.1278,
+    } as never);
 
     const result = await canTutorServiceLocation("tutor-1", { lat: 51.5, lng: -0.1 });
 
@@ -200,14 +213,24 @@ describe("canTutorServiceLocation", () => {
   });
 
   it("returns false when outside service radius", async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ withinRadius: false }]);
+    vi.mocked(prisma.eduTutorProfile.findUnique).mockResolvedValueOnce({
+      onlineOnly: false,
+      serviceRadiusKm: 25,
+      homeLat: 51.5074,
+      homeLng: -0.1278,
+    } as never);
 
     const result = await canTutorServiceLocation("tutor-1", { lat: 60, lng: 0 });
     expect(result).toBe(false);
   });
 
   it("returns false when tutor has no location", async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([]);
+    vi.mocked(prisma.eduTutorProfile.findUnique).mockResolvedValueOnce({
+      onlineOnly: false,
+      serviceRadiusKm: 25,
+      homeLat: null,
+      homeLng: null,
+    } as never);
 
     const result = await canTutorServiceLocation("tutor-no-location", { lat: 51.5, lng: -0.1 });
     expect(result).toBe(false);
@@ -216,11 +239,14 @@ describe("canTutorServiceLocation", () => {
 
 describe("updateTutorLocation", () => {
   it("updates tutor home location with PostGIS point", async () => {
-    vi.mocked(prisma.$executeRaw).mockResolvedValueOnce(1);
+    vi.mocked(prisma.eduTutorProfile.update).mockResolvedValueOnce({} as never);
 
     await updateTutorLocation("tutor-1", { lat: 51.5074, lng: -0.1278 });
 
-    expect(prisma.$executeRaw).toHaveBeenCalled();
+    expect(prisma.eduTutorProfile.update).toHaveBeenCalledWith({
+      where: { userId: "tutor-1" },
+      data: { homeLat: 51.5074, homeLng: -0.1278 },
+    });
   });
 });
 
@@ -236,6 +262,7 @@ function mockTutor() {
     ratingAvg: 4.5,
     ratingCount: 10,
     verifiedAt: new Date(),
-    distanceMeters: 5000,
+    homeLat: 40.75791045708758,
+    homeLng: -74.006,
   };
 }

--- a/apps/edumatch/lib/server/bookings.ts
+++ b/apps/edumatch/lib/server/bookings.ts
@@ -92,6 +92,10 @@ export async function cancelBooking(input: {
     throw new BookingTransitionError("Only the booking's tutor can cancel.");
   }
 
+  if (booking.status === "CANCELLED") {
+    throw new BookingTransitionError("Booking is already cancelled.");
+  }
+
   assertTransitionAllowed(booking.status as BookingStatus, "CANCELLED");
 
   if (!reason?.trim()) {

--- a/apps/edumatch/lib/server/geocoding.ts
+++ b/apps/edumatch/lib/server/geocoding.ts
@@ -18,21 +18,20 @@ export type GeocodeResult = {
 
 export type GeocodeError = { error: string };
 
-const GOOGLE_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
-
 /**
  * Geocode a human-readable address to lat/lng.
  * Returns null in dev mode if API key is not configured.
  */
 export async function geocodeAddress(address: string): Promise<GeocodeResult | GeocodeError | null> {
-  if (!GOOGLE_API_KEY) {
+  const googleApiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!googleApiKey) {
     // Dev fallback: return null to signal "geocoding unavailable"
     return null;
   }
 
   const url = new URL("https://maps.googleapis.com/maps/api/geocode/json");
   url.searchParams.set("address", address);
-  url.searchParams.set("key", GOOGLE_API_KEY);
+  url.searchParams.set("key", googleApiKey);
 
   const res = await fetch(url.toString());
   const data = (await res.json()) as {
@@ -74,11 +73,12 @@ export async function reverseGeocode(
   lat: number,
   lng: number,
 ): Promise<Pick<GeocodeResult, "formattedAddress" | "placeId" | "types"> | GeocodeError | null> {
-  if (!GOOGLE_API_KEY) return null;
+  const googleApiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!googleApiKey) return null;
 
   const url = new URL("https://maps.googleapis.com/maps/api/geocode/json");
   url.searchParams.set("latlng", `${lat},${lng}`);
-  url.searchParams.set("key", GOOGLE_API_KEY);
+  url.searchParams.set("key", googleApiKey);
 
   const res = await fetch(url.toString());
   const data = (await res.json()) as {

--- a/apps/edumatch/lib/server/moderation.ts
+++ b/apps/edumatch/lib/server/moderation.ts
@@ -73,6 +73,7 @@ const REFUSE_RULES: Rule[] = [
     reason: "Plagiarism / detector-evasion request.",
     patterns: [
       /\b(?:rewrite|paraphrase|reword)\s+(?:this|it|my essay|my paper)\s+(?:so|to)\s+(?:that\s+)?(?:my\s+)?(?:professor|teacher|instructor|turnitin|ai detector|gptzero)\b/i,
+      /\b(?:professor|teacher|instructor)\s+can(?:not|'t|n['’]t)\s+tell\s+(?:it(?:'s| is)|this\s+is)\s+ai\b/i,
       /\b(?:bypass|fool|evade|trick|defeat)\s+(?:turnitin|ai detector|gptzero|plagiarism)\b/i,
       /\b(?:undetectable|uncatchable)\s+(?:by|to)\s+(?:turnitin|ai|plagiarism)\b/i,
       /\bmake\s+(?:this|it)\s+(?:look|seem)\s+human(?:-written)?\b/i,

--- a/apps/edumatch/vitest.config.ts
+++ b/apps/edumatch/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
   test: {
     environment: "node",
     include: ["**/__tests__/**/*.test.ts", "**/*.test.ts"],


### PR DESCRIPTION
## Summary

Closes #115.

Restores the EduMatch release verification baseline by fixing the current failing test clusters and one booking behavior mismatch.

Changes:

- Add Vitest `@` alias resolution for EduMatch API route tests.
- Rewrite the inquiry API test to use real `Request` objects and local mocks instead of loading NextAuth or live Prisma/storage/AI services.
- Update Prisma mocks in profile and tutor-matching tests for the current model-based implementation.
- Read `GOOGLE_MAPS_API_KEY` at geocoding call time so env-stubbed tests are deterministic.
- Explicitly reject repeated booking cancellation with `BookingTransitionError`.
- Tighten the plagiarism/detector-evasion moderation rule for “professor can't tell it's AI” prompts.

## Verification

- `pnpm --filter edumatch typecheck`
- `pnpm --filter edumatch test`

Refs #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents cancellation of bookings that are already cancelled, returning an appropriate error message.

* **Security**
  * Expanded plagiarism and detector-evasion detection in content moderation.

* **Chores**
  * Test suite improvements and configuration updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AliSafari-IT/asafarim-digital/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->