### PR TITLE
feat(edumatch): add live admin overview dashboard with aggregated sta…

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["--filter", "vionto", "dev"],
       "port": 3000,
       "autoPort": false
+    },
+    {
+      "name": "edumatch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "edumatch", "dev"],
+      "port": 3005,
+      "autoPort": false
     }
   ]
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(git add *)",
       "Bash(git commit -m ' *)",
       "Bash(pnpm --filter edumatch typecheck)",
-      "PowerShell(pnpm --filter edumatch list @asafarim/navigation 2>&1)"
+      "PowerShell(pnpm --filter edumatch list @asafarim/navigation 2>&1)",
+      "mcp__Claude_Preview__preview_start"
     ]
   }
 }

--- a/apps/edumatch/README.md
+++ b/apps/edumatch/README.md
@@ -127,6 +127,12 @@ pnpm --filter edumatch clean
 | `/admin` | Admin overview dashboard |
 | `/admin/tutor-verifications` | Admin tutor verification queue |
 | `/admin/tutor-matching` | Admin matching diagnostics |
+| `/admin/disputes` | Dispute resolution workbench |
+| `/admin/bookings` | Booking search and detail view |
+| `/admin/payments` | Transaction and wallet overview |
+| `/admin/inquiries` | Inquiry and AI safety browser |
+| `/admin/users` | User, student, and tutor directory |
+| `/admin/audit` | Audit event log viewer |
 | `/privacy`, `/terms`, `/cookies` | Legal pages |
 
 ## API Surface
@@ -143,11 +149,20 @@ pnpm --filter edumatch clean
 | Tutor finance | `/api/tutors/wallet`, `/api/tutors/bookings`, `/api/tutors/quotes` |
 | Admin — verification | `/api/admin/tutor-verifications`, `/api/admin/tutor-verifications/[id]` |
 | Admin — matching | `/api/admin/tutor-matching/debug` |
+| Admin — overview | `/api/admin/overview` |
+| Admin — disputes | `/api/admin/disputes`, `/api/admin/disputes/[id]` |
+| Admin — bookings | `/api/admin/bookings` |
+| Admin — transactions | `/api/admin/transactions` |
+| Admin — users | `/api/admin/users` |
+| Admin — inquiries | `/api/admin/inquiries` |
+| Admin — audit | `/api/admin/audit` |
 | Notifications | `/api/notifications`, `/api/notifications/[id]/mark-read`, `/api/me/notification-preferences` |
 | Platform | `/api/health`, `/api/docs`, `/api/navigation` |
 
 ## Key Modules
 
+- `lib/server/admin-queries.ts`: Admin dashboard aggregations and paginated
+  queries for all admin workbenches.
 - `lib/server/profiles.ts`: EduMatch role resolution and role guards.
 - `lib/server/ai-orchestrator.ts`: multimodal AI processing and provider
   fallback.

--- a/apps/edumatch/__tests__/api/admin-modules.test.ts
+++ b/apps/edumatch/__tests__/api/admin-modules.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+import type { AuthedUser } from "@/lib/server/auth";
+
+function mockUser(roles: string[]): AuthedUser {
+  return { id: "u1", email: "admin@example.com", tenantId: null, roles };
+}
+
+const mockGetAuthedUser = vi.fn<() => Promise<AuthedUser | null>>();
+
+vi.mock("@asafarim/auth", () => ({
+  auth: async () => {
+    const user = await mockGetAuthedUser();
+    if (!user) return null;
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        tenantId: user.tenantId,
+        roles: user.roles,
+      },
+    };
+  },
+}));
+
+vi.mock("@asafarim/db", () => ({
+  prisma: {
+    eduStudentProfile: { findUnique: vi.fn().mockResolvedValue(null), count: vi.fn().mockResolvedValue(0) },
+    eduTutorProfile: { findUnique: vi.fn().mockResolvedValue(null), count: vi.fn().mockResolvedValue(0) },
+    eduTutorVerification: { count: vi.fn().mockResolvedValue(0) },
+    eduBooking: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    eduInquiry: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    eduTransaction: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    eduAuditEvent: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    eduWallet: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    user: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+  },
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  getAuthedUser: () => mockGetAuthedUser(),
+  unauthorized: () => NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  forbidden: (msg = "Forbidden") => NextResponse.json({ error: msg }, { status: 403 }),
+  badRequest: (msg: string) => NextResponse.json({ error: msg }, { status: 400 }),
+  serverError: (_scope: string, error: unknown) =>
+    NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 }),
+}));
+
+vi.mock("@/lib/server", () => ({
+  handleEduError: vi.fn((_scope: string, error: Error & { status?: number }) => {
+    const status = error.status ?? 500;
+    return NextResponse.json({ error: error.message }, { status });
+  }),
+  getAuthedUser: () => mockGetAuthedUser(),
+  badRequest: (msg: string) => NextResponse.json({ error: msg }, { status: 400 }),
+  serverError: (_scope: string, error: unknown) =>
+    NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const adminRoutes = [
+  { name: "overview", path: "@/app/api/admin/overview/route" },
+  { name: "disputes", path: "@/app/api/admin/disputes/route" },
+  { name: "bookings", path: "@/app/api/admin/bookings/route" },
+  { name: "transactions", path: "@/app/api/admin/transactions/route" },
+  { name: "users", path: "@/app/api/admin/users/route" },
+  { name: "inquiries", path: "@/app/api/admin/inquiries/route" },
+  { name: "audit", path: "@/app/api/admin/audit/route" },
+];
+
+for (const route of adminRoutes) {
+  describe(`GET /api/admin/${route.name}`, () => {
+    it("returns 401 for unauthenticated user", async () => {
+      mockGetAuthedUser.mockResolvedValue(null);
+      const mod = await import(route.path);
+      const req = new Request("http://localhost") as never;
+      const res = await mod.GET(req);
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 for student user", async () => {
+      mockGetAuthedUser.mockResolvedValue(mockUser(["edumatch_student"]));
+      const mod = await import(route.path);
+      const req = new Request("http://localhost") as never;
+      const res = await mod.GET(req);
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 200 for admin user", async () => {
+      mockGetAuthedUser.mockResolvedValue(mockUser(["edumatch_admin"]));
+      const mod = await import(route.path);
+      const req = new Request("http://localhost") as never;
+      const res = await mod.GET(req);
+      expect(res.status).toBe(200);
+    });
+  });
+}

--- a/apps/edumatch/app/admin/AdminShell.tsx
+++ b/apps/edumatch/app/admin/AdminShell.tsx
@@ -15,12 +15,12 @@ const adminNav: AdminNavItem[] = [
   { label: "Overview", href: "/admin", icon: "OV" },
   { label: "Tutor Verifications", href: "/admin/tutor-verifications", icon: "TV" },
   { label: "Matching Debug", href: "/admin/tutor-matching", icon: "MD" },
-  { label: "Disputes", href: "/admin/disputes", icon: "DS", disabled: true },
-  { label: "Bookings", href: "/admin/bookings", icon: "BK", disabled: true },
-  { label: "Payments", href: "/admin/payments", icon: "PY", disabled: true },
-  { label: "Inquiries", href: "/admin/inquiries", icon: "IQ", disabled: true },
-  { label: "Users & Tutors", href: "/admin/users", icon: "UT", disabled: true },
-  { label: "Audit Log", href: "/admin/audit", icon: "AU", disabled: true },
+  { label: "Disputes", href: "/admin/disputes", icon: "DS" },
+  { label: "Bookings", href: "/admin/bookings", icon: "BK" },
+  { label: "Payments", href: "/admin/payments", icon: "PY" },
+  { label: "Inquiries", href: "/admin/inquiries", icon: "IQ" },
+  { label: "Users & Tutors", href: "/admin/users", icon: "UT" },
+  { label: "Audit Log", href: "/admin/audit", icon: "AU" },
 ];
 
 function isActive(href: string, pathname: string) {
@@ -66,6 +66,25 @@ export function AdminShell({
         </div>
       </header>
 
+      {/* Mobile nav — outside the sidebar flex so it stacks vertically */}
+      <div className="md:hidden border-b border-[var(--color-border)] overflow-x-auto">
+        <nav className="flex gap-1 p-2">
+          {adminNav.filter((i) => !i.disabled).map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`whitespace-nowrap rounded-md px-3 py-1.5 text-sm transition-colors ${
+                isActive(item.href, pathname)
+                  ? "bg-emerald-500/15 font-medium text-emerald-400"
+                  : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface)]"
+              }`}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+
       <div className="flex">
         {/* Desktop sidebar */}
         <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-bg)] md:block">
@@ -104,25 +123,6 @@ export function AdminShell({
             })}
           </nav>
         </aside>
-
-        {/* Mobile nav */}
-        <div className="w-full md:hidden border-b border-[var(--color-border)] overflow-x-auto">
-          <nav className="flex gap-1 p-2">
-            {adminNav.filter((i) => !i.disabled).map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={`whitespace-nowrap rounded-md px-3 py-1.5 text-sm transition-colors ${
-                  isActive(item.href, pathname)
-                    ? "bg-emerald-500/15 font-medium text-emerald-400"
-                    : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface)]"
-                }`}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-        </div>
 
         <main className="min-w-0 flex-1 p-4 sm:p-6">{children}</main>
       </div>

--- a/apps/edumatch/app/admin/audit/page.tsx
+++ b/apps/edumatch/app/admin/audit/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminFetch } from "../useAdminFetch";
+
+type AuditEvent = {
+  id: string;
+  actorId: string | null;
+  actorRole: string | null;
+  action: string;
+  entity: string;
+  entityId: string | null;
+  prevState: string | null;
+  nextState: string | null;
+  reason: string | null;
+  createdAt: string;
+  actor: { id: string; name: string | null; email: string | null } | null;
+};
+
+const ENTITY_OPTIONS = [
+  "",
+  "EduInquiry",
+  "EduAiResponse",
+  "EduQuote",
+  "EduBooking",
+  "EduTransaction",
+  "EduTutorVerification",
+  "EduTutorProfile",
+] as const;
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+export default function AuditPage() {
+  const [entityFilter, setEntityFilter] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+
+  const params = new URLSearchParams({ limit: "100" });
+  if (entityFilter) params.set("entity", entityFilter);
+  if (actionFilter) params.set("action", actionFilter);
+
+  const { data, loading, error } = useAdminFetch<{ events: AuditEvent[] }>(
+    `/api/admin/audit?${params}`,
+  );
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">Audit Log</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-4">Append-only log of EduMatch state changes.</p>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:gap-3 mb-6">
+        <select
+          value={entityFilter}
+          onChange={(e) => setEntityFilter(e.target.value)}
+          className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+        >
+          {ENTITY_OPTIONS.map((e) => (
+            <option key={e} value={e}>{e || "All entities"}</option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={actionFilter}
+          onChange={(e) => setActionFilter(e.target.value)}
+          placeholder="Filter by action..."
+          className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+        />
+      </div>
+
+      {error && <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{error}</div>}
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+      ) : !data || data.events.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">No audit events found.</p>
+      ) : (
+        <>
+          {/* Mobile cards */}
+          <div className="space-y-3 md:hidden">
+            {data.events.map((e) => (
+              <div key={e.id} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <span className="text-sm font-semibold text-[var(--color-text)] break-all">{e.action}</span>
+                  {e.actorRole && <RoleBadge role={e.actorRole} />}
+                </div>
+                <div className="space-y-1 text-xs text-[var(--color-text-muted)]">
+                  <p>
+                    <span className="font-medium">Entity:</span> {e.entity}
+                    {e.entityId && <span className="opacity-60"> {e.entityId.slice(0, 8)}...</span>}
+                  </p>
+                  {(e.prevState || e.nextState) && (
+                    <p>
+                      <span className="font-medium">Transition:</span>{" "}
+                      {e.prevState && <span className="text-red-400">{e.prevState}</span>}
+                      {e.prevState && e.nextState && " → "}
+                      {e.nextState && <span className="text-green-400">{e.nextState}</span>}
+                    </p>
+                  )}
+                  <p>
+                    <span className="font-medium">Actor:</span>{" "}
+                    {e.actor ? (e.actor.name ?? e.actor.email) : e.actorId ? e.actorId.slice(0, 8) : "system"}
+                  </p>
+                  {e.reason && <p className="line-clamp-2"><span className="font-medium">Reason:</span> {e.reason}</p>}
+                  <p className="text-[var(--color-text-muted)] opacity-60">{formatTime(e.createdAt)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--color-border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Action</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Entity</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Transition</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Actor</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Role</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Reason</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.events.map((e) => (
+                  <tr key={e.id} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface)]">
+                    <td className="px-3 py-2 font-medium text-[var(--color-text)]">{e.action}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">
+                      {e.entity}
+                      {e.entityId && <span className="text-[var(--color-text-muted)] opacity-60"> {e.entityId.slice(0, 8)}...</span>}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">
+                      {e.prevState || e.nextState ? (
+                        <>
+                          {e.prevState && <span className="text-red-400">{e.prevState}</span>}
+                          {e.prevState && e.nextState && <span> &rarr; </span>}
+                          {e.nextState && <span className="text-green-400">{e.nextState}</span>}
+                        </>
+                      ) : (
+                        "-"
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">
+                      {e.actor ? (e.actor.name ?? e.actor.email) : e.actorId ? e.actorId.slice(0, 8) : "system"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {e.actorRole && <RoleBadge role={e.actorRole} />}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)] max-w-[200px] truncate" title={e.reason ?? ""}>
+                      {e.reason ?? "-"}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)] whitespace-nowrap">{formatTime(e.createdAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function RoleBadge({ role }: { role: string }) {
+  const colors: Record<string, string> = {
+    STUDENT: "bg-blue-500/15 text-blue-400",
+    TUTOR: "bg-emerald-500/15 text-emerald-400",
+    ADMIN: "bg-purple-500/15 text-purple-400",
+    SYSTEM: "bg-gray-500/15 text-gray-400",
+  };
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[role] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {role}
+    </span>
+  );
+}

--- a/apps/edumatch/app/admin/bookings/page.tsx
+++ b/apps/edumatch/app/admin/bookings/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminFetch } from "../useAdminFetch";
+
+type Booking = {
+  id: string;
+  quoteId: string;
+  status: string;
+  mode: string;
+  scheduledAt: string;
+  durationMinutes: number;
+  completedAt: string | null;
+  cancelledAt: string | null;
+  cancellationReason: string | null;
+  stripePaymentIntentId: string | null;
+  createdAt: string;
+  student: { id: string; name: string | null; email: string | null };
+  tutor: { id: string; name: string | null; email: string | null };
+};
+
+const STATUSES = ["", "SCHEDULED", "COMPLETED", "CANCELLED", "DISPUTED"] as const;
+
+export default function BookingsPage() {
+  const [statusFilter, setStatusFilter] = useState("");
+  const url = `/api/admin/bookings?limit=50${statusFilter ? `&status=${statusFilter}` : ""}`;
+  const { data, loading, error } = useAdminFetch<{ items: Booking[]; total: number }>(url);
+
+  return (
+    <div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-[var(--color-text)]">Bookings</h1>
+          <p className="text-sm text-[var(--color-text-muted)] mt-1">All EduMatch bookings.</p>
+        </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="w-full sm:w-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+        >
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{s || "All statuses"}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{error}</div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+      ) : !data || data.items.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">No bookings found.</p>
+      ) : (
+        <>
+          <p className="text-xs text-[var(--color-text-muted)] mb-3">{data.total} total</p>
+
+          {/* Mobile cards */}
+          <div className="space-y-3 md:hidden">
+            {data.items.map((b) => (
+              <div key={b.id} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="min-w-0">
+                    <p className="font-semibold text-[var(--color-text)] truncate">
+                      {b.student.name ?? b.student.email}
+                    </p>
+                    <p className="text-xs text-[var(--color-text-muted)]">
+                      &rarr; {b.tutor.name ?? b.tutor.email}
+                    </p>
+                  </div>
+                  <StatusBadge status={b.status} />
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--color-text-muted)]">
+                  <span>{b.mode}</span>
+                  <span>{b.durationMinutes}min</span>
+                  <span>{new Date(b.scheduledAt).toLocaleDateString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--color-border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Student</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Tutor</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Status</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Mode</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Scheduled</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Duration</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.items.map((b) => (
+                  <tr key={b.id} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface)]">
+                    <td className="px-3 py-2 text-[var(--color-text)]">{b.student.name ?? b.student.email}</td>
+                    <td className="px-3 py-2 text-[var(--color-text)]">{b.tutor.name ?? b.tutor.email}</td>
+                    <td className="px-3 py-2"><StatusBadge status={b.status} /></td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{b.mode}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{new Date(b.scheduledAt).toLocaleDateString()}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{b.durationMinutes}min</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{new Date(b.createdAt).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    SCHEDULED: "bg-blue-500/15 text-blue-400",
+    COMPLETED: "bg-green-500/15 text-green-400",
+    CANCELLED: "bg-red-500/15 text-red-400",
+    DISPUTED: "bg-orange-500/15 text-orange-400",
+  };
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[status] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {status}
+    </span>
+  );
+}

--- a/apps/edumatch/app/admin/disputes/page.tsx
+++ b/apps/edumatch/app/admin/disputes/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminFetch } from "../useAdminFetch";
+
+type Dispute = {
+  id: string;
+  quoteId: string;
+  status: string;
+  mode: string;
+  scheduledAt: string;
+  cancelledAt: string | null;
+  cancellationReason: string | null;
+  stripePaymentIntentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  student: { id: string; name: string | null; email: string | null };
+  tutor: { id: string; name: string | null; email: string | null };
+  transactions: { id: string; type: string; grossCents: number; netCents: number; createdAt: string }[];
+};
+
+export default function DisputesPage() {
+  const { data, loading, error, reload } = useAdminFetch<{ items: Dispute[]; total: number }>("/api/admin/disputes");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+
+  async function resolve(bookingId: string, resolution: "REFUND" | "NO_REFUND") {
+    setBusy(bookingId);
+    setResolveError(null);
+    try {
+      const res = await fetch(`/api/admin/disputes/${bookingId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resolution, reason: notes[bookingId] || `Admin resolved: ${resolution}` }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      await reload();
+    } catch (e) {
+      setResolveError(e instanceof Error ? e.message : "Failed to resolve");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">Disputes</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-6">Disputed bookings requiring admin resolution.</p>
+
+      {(error || resolveError) && (
+        <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          {error || resolveError}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+      ) : !data || data.items.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">No open disputes.</p>
+      ) : (
+        <div className="space-y-4">
+          {data.items.map((d) => (
+            <div key={d.id} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-5">
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div>
+                  <p className="font-semibold text-[var(--color-text)]">
+                    {d.student.name ?? d.student.email} &rarr; {d.tutor.name ?? d.tutor.email}
+                  </p>
+                  <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+                    Booking {d.id.slice(0, 8)}... &middot; {d.mode} &middot; Scheduled {new Date(d.scheduledAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <span className="rounded-full bg-orange-500/15 px-2 py-0.5 text-xs font-medium text-orange-400">DISPUTED</span>
+              </div>
+
+              {d.cancellationReason && (
+                <p className="text-sm text-[var(--color-text)] opacity-80 mb-3 whitespace-pre-wrap">{d.cancellationReason}</p>
+              )}
+
+              {d.transactions.length > 0 && (
+                <div className="mb-3">
+                  <p className="text-xs font-medium text-[var(--color-text-muted)] mb-1">Transactions</p>
+                  {d.transactions.map((t) => (
+                    <p key={t.id} className="text-xs text-[var(--color-text-muted)]">
+                      {t.type}: &euro;{(t.grossCents / 100).toFixed(2)} ({new Date(t.createdAt).toLocaleDateString()})
+                    </p>
+                  ))}
+                </div>
+              )}
+
+              <div className="mb-3">
+                <label className="block text-xs font-medium text-[var(--color-text-muted)] mb-1">Admin resolution notes</label>
+                <textarea
+                  value={notes[d.id] ?? ""}
+                  onChange={(e) => setNotes((n) => ({ ...n, [d.id]: e.target.value }))}
+                  rows={2}
+                  className="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-2 text-sm text-[var(--color-text)]"
+                  placeholder="Reason for resolution..."
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  disabled={busy === d.id}
+                  onClick={() => resolve(d.id, "REFUND")}
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                >
+                  {busy === d.id ? "Working..." : "Refund & Cancel"}
+                </button>
+                <button
+                  disabled={busy === d.id}
+                  onClick={() => resolve(d.id, "NO_REFUND")}
+                  className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                >
+                  No Refund (Complete)
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/edumatch/app/admin/inquiries/page.tsx
+++ b/apps/edumatch/app/admin/inquiries/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminFetch } from "../useAdminFetch";
+
+type Inquiry = {
+  id: string;
+  subject: string;
+  gradeLevel: string;
+  status: string;
+  moderationOutcome: string | null;
+  moderationCategory: string | null;
+  createdAt: string;
+  student: { id: string; name: string | null; email: string | null };
+  aiResponses: { modelUsed: string; moderationOutcome: string | null }[];
+};
+
+const STATUS_OPTIONS = ["", "NEW", "AI_RESPONDED", "TUTOR_REQUESTED", "BOOKED", "CLOSED", "REFUSED"] as const;
+const MOD_OPTIONS = ["", "ALLOW", "REVIEW", "REFUSE"] as const;
+
+export default function InquiriesPage() {
+  const [statusFilter, setStatusFilter] = useState("");
+  const [modFilter, setModFilter] = useState("");
+
+  const params = new URLSearchParams({ limit: "50" });
+  if (statusFilter) params.set("status", statusFilter);
+  if (modFilter) params.set("moderationOutcome", modFilter);
+
+  const { data, loading, error } = useAdminFetch<{ items: Inquiry[]; total: number }>(
+    `/api/admin/inquiries?${params}`,
+  );
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">Inquiries & AI Safety</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-4">Student inquiries, AI responses, and moderation.</p>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:gap-3 mb-6">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s || "All statuses"}</option>
+          ))}
+        </select>
+        <select
+          value={modFilter}
+          onChange={(e) => setModFilter(e.target.value)}
+          className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+        >
+          {MOD_OPTIONS.map((m) => (
+            <option key={m} value={m}>{m ? `Moderation: ${m}` : "All moderation"}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{error}</div>}
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+      ) : !data || data.items.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">No inquiries found.</p>
+      ) : (
+        <>
+          <p className="text-xs text-[var(--color-text-muted)] mb-3">{data.total} total</p>
+
+          {/* Mobile cards */}
+          <div className="space-y-3 md:hidden">
+            {data.items.map((i) => (
+              <div key={i.id} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="min-w-0">
+                    <p className="font-semibold text-[var(--color-text)]">{i.subject}</p>
+                    <p className="text-xs text-[var(--color-text-muted)]">{i.gradeLevel} &middot; {i.student.name ?? i.student.email}</p>
+                  </div>
+                  <StatusBadge status={i.status} />
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-xs">
+                  {i.moderationOutcome && (
+                    <ModBadge outcome={i.moderationOutcome} category={i.moderationCategory} />
+                  )}
+                  {i.aiResponses[0] && (
+                    <span className="text-[var(--color-text-muted)]">AI: {i.aiResponses[0].modelUsed}</span>
+                  )}
+                  <span className="text-[var(--color-text-muted)] ml-auto">{new Date(i.createdAt).toLocaleDateString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--color-border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Subject</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Grade</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Student</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Status</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Moderation</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">AI Model</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.items.map((i) => (
+                  <tr key={i.id} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface)]">
+                    <td className="px-3 py-2 text-[var(--color-text)]">{i.subject}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{i.gradeLevel}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{i.student.name ?? i.student.email}</td>
+                    <td className="px-3 py-2"><StatusBadge status={i.status} /></td>
+                    <td className="px-3 py-2">
+                      {i.moderationOutcome ? (
+                        <ModBadge outcome={i.moderationOutcome} category={i.moderationCategory} />
+                      ) : (
+                        <span className="text-xs text-[var(--color-text-muted)]">-</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)] text-xs">{i.aiResponses[0]?.modelUsed ?? "-"}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{new Date(i.createdAt).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    NEW: "bg-blue-500/15 text-blue-400",
+    AI_RESPONDED: "bg-emerald-500/15 text-emerald-400",
+    TUTOR_REQUESTED: "bg-yellow-500/15 text-yellow-400",
+    BOOKED: "bg-green-500/15 text-green-400",
+    CLOSED: "bg-gray-500/15 text-gray-400",
+    REFUSED: "bg-red-500/15 text-red-400",
+  };
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[status] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {status}
+    </span>
+  );
+}
+
+function ModBadge({ outcome, category }: { outcome: string; category: string | null }) {
+  const colors: Record<string, string> = {
+    ALLOW: "bg-green-500/15 text-green-400",
+    REVIEW: "bg-yellow-500/15 text-yellow-400",
+    REFUSE: "bg-red-500/15 text-red-400",
+  };
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[outcome] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {outcome}{category && category !== "NONE" ? ` (${category})` : ""}
+    </span>
+  );
+}

--- a/apps/edumatch/app/admin/page.tsx
+++ b/apps/edumatch/app/admin/page.tsx
@@ -1,111 +1,238 @@
-import Link from "next/link";
+"use client";
 
-const sections = [
-  {
-    label: "Tutor Verifications",
-    href: "/admin/tutor-verifications",
-    description: "Review and approve tutor profiles.",
-    icon: "TV",
-  },
-  {
-    label: "Matching Debug",
-    href: "/admin/tutor-matching",
-    description: "Test the tutor matching algorithm.",
-    icon: "MD",
-  },
-  {
-    label: "Disputes",
-    href: "/admin/disputes",
-    description: "Handle booking disputes.",
-    icon: "DS",
-    disabled: true,
-  },
-  {
-    label: "Bookings",
-    href: "/admin/bookings",
-    description: "View and manage bookings.",
-    icon: "BK",
-    disabled: true,
-  },
-  {
-    label: "Payments & Transactions",
-    href: "/admin/payments",
-    description: "Track payments and payouts.",
-    icon: "PY",
-    disabled: true,
-  },
-  {
-    label: "Inquiries",
-    href: "/admin/inquiries",
-    description: "Browse student inquiries.",
-    icon: "IQ",
-    disabled: true,
-  },
-  {
-    label: "Users & Tutors",
-    href: "/admin/users",
-    description: "Manage user accounts and tutor profiles.",
-    icon: "UT",
-    disabled: true,
-  },
-  {
-    label: "Audit Log",
-    href: "/admin/audit",
-    description: "Append-only log of sensitive operations.",
-    icon: "AU",
-    disabled: true,
-  },
+import Link from "next/link";
+import { useAdminFetch } from "./useAdminFetch";
+
+type OverviewData = {
+  openVerifications: number;
+  disputedBookings: number;
+  refusedInquiries: number;
+  totalStudents: number;
+  totalTutors: number;
+  recentBookings: {
+    id: string;
+    status: string;
+    scheduledAt: string;
+    createdAt: string;
+    student: { name: string | null; email: string | null };
+    tutor: { name: string | null; email: string | null };
+  }[];
+  recentInquiries: {
+    id: string;
+    subject: string;
+    status: string;
+    moderationOutcome: string | null;
+    createdAt: string;
+    student: { name: string | null; email: string | null };
+  }[];
+  recentTransactions: {
+    id: string;
+    type: string;
+    grossCents: number;
+    netCents: number;
+    currency: string;
+    createdAt: string;
+  }[];
+  recentAuditEvents: {
+    id: string;
+    action: string;
+    entity: string;
+    entityId: string | null;
+    actorRole: string | null;
+    createdAt: string;
+    actor: { name: string | null; email: string | null } | null;
+  }[];
+};
+
+const statCards = [
+  { key: "openVerifications" as const, label: "Open Verifications", href: "/admin/tutor-verifications", color: "text-yellow-400" },
+  { key: "disputedBookings" as const, label: "Open Disputes", href: "/admin/disputes", color: "text-red-400" },
+  { key: "refusedInquiries" as const, label: "Refused Inquiries", href: "/admin/inquiries?moderationOutcome=REFUSE", color: "text-orange-400" },
+  { key: "totalStudents" as const, label: "Students", href: "/admin/users", color: "text-emerald-400" },
+  { key: "totalTutors" as const, label: "Tutors", href: "/admin/users", color: "text-blue-400" },
 ];
 
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function cents(c: number, currency = "EUR") {
+  return `${currency === "EUR" ? "€" : "$"}${(c / 100).toFixed(2)}`;
+}
+
 export default function AdminOverviewPage() {
+  const { data, loading, error } = useAdminFetch<OverviewData>("/api/admin/overview");
+
+  if (loading) {
+    return <p className="text-sm text-[var(--color-text-muted)]">Loading dashboard...</p>;
+  }
+  if (error) {
+    return <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{error}</div>;
+  }
+  if (!data) return null;
+
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-[var(--color-text)]">
-          EduMatch Admin
-        </h1>
+        <h1 className="text-2xl font-bold text-[var(--color-text)]">EduMatch Admin</h1>
         <p className="mt-1 text-sm text-[var(--color-text-muted)]">
           Manage tutors, verifications, disputes, and platform operations.
         </p>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {sections.map((s) => {
-          const card = (
-            <div
-              className={`rounded-lg border p-5 transition ${
-                s.disabled
-                  ? "border-[var(--color-border)] opacity-50 cursor-not-allowed"
-                  : "border-[var(--color-border)] hover:border-emerald-500/40 hover:shadow-md"
-              }`}
-            >
-              <div className="flex items-center gap-2.5">
-                <span className="flex h-8 w-8 items-center justify-center rounded-md bg-emerald-500/15 text-xs font-bold text-emerald-400">
-                  {s.icon}
-                </span>
-                <h2 className="font-semibold text-[var(--color-text)]">
-                  {s.label}
-                </h2>
-              </div>
-              <p className="mt-2 text-sm text-[var(--color-text-muted)]">
-                {s.description}
-              </p>
-              {s.disabled && (
-                <span className="mt-3 inline-block rounded-full border border-[var(--color-border)] px-2 py-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
-                  Coming soon
-                </span>
-              )}
-            </div>
-          );
+      {/* Stat cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5 mb-8">
+        {statCards.map((s) => (
+          <Link
+            key={s.key}
+            href={s.href}
+            className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4 transition hover:border-emerald-500/40"
+          >
+            <p className="text-sm text-[var(--color-text-muted)]">{s.label}</p>
+            <p className={`mt-1 text-2xl font-bold ${s.color}`}>{data[s.key]}</p>
+          </Link>
+        ))}
+      </div>
 
-          if (s.disabled) return <div key={s.href}>{card}</div>;
-          return (
-            <Link key={s.href} href={s.href} className="block">
-              {card}
-            </Link>
-          );
-        })}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Recent bookings */}
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-semibold text-[var(--color-text)]">Recent Bookings</h2>
+            <Link href="/admin/bookings" className="text-xs text-emerald-400 hover:underline">View all</Link>
+          </div>
+          {data.recentBookings.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">No bookings yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.recentBookings.map((b) => (
+                <div key={b.id} className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm">
+                  <div className="min-w-0">
+                    <span className="text-[var(--color-text)]">{b.student.name ?? b.student.email}</span>
+                    <span className="text-[var(--color-text-muted)]"> &rarr; </span>
+                    <span className="text-[var(--color-text)]">{b.tutor.name ?? b.tutor.email}</span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge status={b.status} />
+                    <span className="text-xs text-[var(--color-text-muted)]">{formatDate(b.createdAt)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Recent inquiries */}
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-semibold text-[var(--color-text)]">Recent Inquiries</h2>
+            <Link href="/admin/inquiries" className="text-xs text-emerald-400 hover:underline">View all</Link>
+          </div>
+          {data.recentInquiries.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">No inquiries yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.recentInquiries.map((i) => (
+                <div key={i.id} className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm">
+                  <div className="min-w-0">
+                    <span className="text-[var(--color-text)]">{i.subject}</span>
+                    <span className="text-[var(--color-text-muted)]"> by {i.student.name ?? i.student.email}</span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge status={i.status} />
+                    {i.moderationOutcome === "REFUSE" && (
+                      <span className="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-medium text-red-400">REFUSED</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Recent transactions */}
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-semibold text-[var(--color-text)]">Recent Transactions</h2>
+            <Link href="/admin/payments" className="text-xs text-emerald-400 hover:underline">View all</Link>
+          </div>
+          {data.recentTransactions.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">No transactions yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.recentTransactions.map((t) => (
+                <div key={t.id} className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    <TxTypeBadge type={t.type} />
+                    <span className="text-[var(--color-text)]">{cents(t.grossCents, t.currency)}</span>
+                  </div>
+                  <span className="text-xs text-[var(--color-text-muted)]">{formatDate(t.createdAt)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Recent audit events */}
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-semibold text-[var(--color-text)]">Recent Audit Events</h2>
+            <Link href="/admin/audit" className="text-xs text-emerald-400 hover:underline">View all</Link>
+          </div>
+          {data.recentAuditEvents.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">No audit events yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.recentAuditEvents.map((e) => (
+                <div key={e.id} className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm">
+                  <div className="min-w-0">
+                    <span className="font-medium text-[var(--color-text)]">{e.action}</span>
+                    <span className="text-[var(--color-text-muted)]"> on {e.entity}</span>
+                    {e.actor && (
+                      <span className="text-[var(--color-text-muted)]"> by {e.actor.name ?? e.actor.email}</span>
+                    )}
+                  </div>
+                  <span className="text-xs text-[var(--color-text-muted)] shrink-0">{formatDate(e.createdAt)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    SCHEDULED: "bg-blue-500/15 text-blue-400",
+    COMPLETED: "bg-green-500/15 text-green-400",
+    CANCELLED: "bg-red-500/15 text-red-400",
+    DISPUTED: "bg-orange-500/15 text-orange-400",
+    NEW: "bg-blue-500/15 text-blue-400",
+    AI_RESPONDED: "bg-emerald-500/15 text-emerald-400",
+    TUTOR_REQUESTED: "bg-yellow-500/15 text-yellow-400",
+    BOOKED: "bg-green-500/15 text-green-400",
+    CLOSED: "bg-gray-500/15 text-gray-400",
+    REFUSED: "bg-red-500/15 text-red-400",
+  };
+  return (
+    <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[status] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {status}
+    </span>
+  );
+}
+
+function TxTypeBadge({ type }: { type: string }) {
+  const colors: Record<string, string> = {
+    CHARGE: "bg-green-500/15 text-green-400",
+    REFUND: "bg-red-500/15 text-red-400",
+    PAYOUT: "bg-blue-500/15 text-blue-400",
+    PLATFORM_FEE: "bg-purple-500/15 text-purple-400",
+  };
+  return (
+    <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[type] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {type}
+    </span>
   );
 }

--- a/apps/edumatch/app/admin/payments/page.tsx
+++ b/apps/edumatch/app/admin/payments/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminFetch } from "../useAdminFetch";
+
+type Transaction = {
+  id: string;
+  bookingId: string;
+  type: string;
+  grossCents: number;
+  platformFeeCents: number;
+  netCents: number;
+  currency: string;
+  stripeChargeId: string | null;
+  stripePayoutId: string | null;
+  createdAt: string;
+  tutor: { id: string; name: string | null; email: string | null };
+};
+
+type WalletRow = {
+  tutorId: string;
+  balanceCents: number;
+  pendingCents: number;
+  lastPayoutAt: string | null;
+  currency: string;
+  tutor: { name: string | null; email: string | null };
+};
+
+const TX_TYPES = ["", "CHARGE", "REFUND", "PAYOUT", "PLATFORM_FEE"] as const;
+
+function cents(c: number, cur = "EUR") {
+  return `${cur === "EUR" ? "€" : "$"}${(Math.abs(c) / 100).toFixed(2)}`;
+}
+
+export default function PaymentsPage() {
+  const [tab, setTab] = useState<"transactions" | "wallets">("transactions");
+  const [typeFilter, setTypeFilter] = useState("");
+
+  const txUrl = `/api/admin/transactions?limit=50${typeFilter ? `&type=${typeFilter}` : ""}`;
+  const walletUrl = "/api/admin/transactions?view=wallets&limit=50";
+
+  const tx = useAdminFetch<{ items: Transaction[]; total: number }>(txUrl);
+  const wallets = useAdminFetch<{ items: WalletRow[]; total: number }>(walletUrl);
+
+  const active = tab === "transactions";
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-[var(--color-text)] mb-1">Payments & Transactions</h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-4">Financial overview for the EduMatch marketplace.</p>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3 mb-6">
+        <div className="flex gap-2">
+          {(["transactions", "wallets"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium border transition-colors ${
+                tab === t
+                  ? "bg-emerald-600 text-white border-emerald-600"
+                  : "bg-[var(--color-surface)] text-[var(--color-text-muted)] border-[var(--color-border)] hover:bg-[var(--color-panel)]"
+              }`}
+            >
+              {t === "transactions" ? "Transactions" : "Wallets"}
+            </button>
+          ))}
+        </div>
+        {active && (
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="w-full sm:w-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+          >
+            {TX_TYPES.map((t) => (
+              <option key={t} value={t}>{t || "All types"}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {active ? (
+        <>
+          {tx.error && <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{tx.error}</div>}
+
+          {tx.loading ? (
+            <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+          ) : !tx.data || tx.data.items.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">No transactions found.</p>
+          ) : (
+            <>
+              <p className="text-xs text-[var(--color-text-muted)] mb-3">{tx.data.total} total</p>
+
+              {/* Mobile cards */}
+              <div className="space-y-3 md:hidden">
+                {tx.data.items.map((t) => (
+                  <div key={t.id} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+                    <div className="flex items-center justify-between gap-2 mb-2">
+                      <div className="flex items-center gap-2">
+                        <TxBadge type={t.type} />
+                        <span className="font-semibold text-[var(--color-text)]">{cents(t.grossCents, t.currency)}</span>
+                      </div>
+                      <span className="text-xs text-[var(--color-text-muted)]">{new Date(t.createdAt).toLocaleDateString()}</span>
+                    </div>
+                    <div className="text-xs text-[var(--color-text-muted)] space-y-0.5">
+                      <p>Tutor: {t.tutor.name ?? t.tutor.email}</p>
+                      <p>Fee: {cents(t.platformFeeCents, t.currency)} &middot; Net: {t.netCents < 0 ? "-" : ""}{cents(t.netCents, t.currency)}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Desktop table */}
+              <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--color-border)]">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                      <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Type</th>
+                      <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Tutor</th>
+                      <th className="px-3 py-2 text-right font-medium text-[var(--color-text-muted)]">Gross</th>
+                      <th className="px-3 py-2 text-right font-medium text-[var(--color-text-muted)]">Fee</th>
+                      <th className="px-3 py-2 text-right font-medium text-[var(--color-text-muted)]">Net</th>
+                      <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Date</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {tx.data.items.map((t) => (
+                      <tr key={t.id} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface)]">
+                        <td className="px-3 py-2"><TxBadge type={t.type} /></td>
+                        <td className="px-3 py-2 text-[var(--color-text)]">{t.tutor.name ?? t.tutor.email}</td>
+                        <td className="px-3 py-2 text-right text-[var(--color-text)]">{cents(t.grossCents, t.currency)}</td>
+                        <td className="px-3 py-2 text-right text-[var(--color-text-muted)]">{cents(t.platformFeeCents, t.currency)}</td>
+                        <td className="px-3 py-2 text-right text-[var(--color-text)]">{t.netCents < 0 ? "-" : ""}{cents(t.netCents, t.currency)}</td>
+                        <td className="px-3 py-2 text-[var(--color-text-muted)]">{new Date(t.createdAt).toLocaleDateString()}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </>
+      ) : (
+        <>
+          {wallets.error && <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{wallets.error}</div>}
+          {wallets.loading ? (
+            <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+          ) : !wallets.data || wallets.data.items.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">No wallets found.</p>
+          ) : (
+            <>
+              {/* Mobile cards */}
+              <div className="space-y-3 md:hidden">
+                {wallets.data.items.map((w) => (
+                  <div key={w.tutorId} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+                    <p className="font-semibold text-[var(--color-text)] mb-2">{w.tutor.name ?? w.tutor.email}</p>
+                    <div className="flex gap-4 text-xs">
+                      <div>
+                        <p className="text-[var(--color-text-muted)]">Balance</p>
+                        <p className="font-medium text-[var(--color-text)]">{cents(w.balanceCents, w.currency)}</p>
+                      </div>
+                      <div>
+                        <p className="text-[var(--color-text-muted)]">Pending</p>
+                        <p className="font-medium text-yellow-400">{cents(w.pendingCents, w.currency)}</p>
+                      </div>
+                      <div>
+                        <p className="text-[var(--color-text-muted)]">Last payout</p>
+                        <p className="text-[var(--color-text)]">{w.lastPayoutAt ? new Date(w.lastPayoutAt).toLocaleDateString() : "Never"}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Desktop table */}
+              <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--color-border)]">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                      <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Tutor</th>
+                      <th className="px-3 py-2 text-right font-medium text-[var(--color-text-muted)]">Balance</th>
+                      <th className="px-3 py-2 text-right font-medium text-[var(--color-text-muted)]">Pending</th>
+                      <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Last Payout</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {wallets.data.items.map((w) => (
+                      <tr key={w.tutorId} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface)]">
+                        <td className="px-3 py-2 text-[var(--color-text)]">{w.tutor.name ?? w.tutor.email}</td>
+                        <td className="px-3 py-2 text-right text-[var(--color-text)]">{cents(w.balanceCents, w.currency)}</td>
+                        <td className="px-3 py-2 text-right text-yellow-400">{cents(w.pendingCents, w.currency)}</td>
+                        <td className="px-3 py-2 text-[var(--color-text-muted)]">{w.lastPayoutAt ? new Date(w.lastPayoutAt).toLocaleDateString() : "Never"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function TxBadge({ type }: { type: string }) {
+  const colors: Record<string, string> = {
+    CHARGE: "bg-green-500/15 text-green-400",
+    REFUND: "bg-red-500/15 text-red-400",
+    PAYOUT: "bg-blue-500/15 text-blue-400",
+    PLATFORM_FEE: "bg-purple-500/15 text-purple-400",
+  };
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors[type] ?? "bg-gray-500/15 text-gray-400"}`}>
+      {type}
+    </span>
+  );
+}

--- a/apps/edumatch/app/admin/useAdminFetch.ts
+++ b/apps/edumatch/app/admin/useAdminFetch.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export function useAdminFetch<T>(url: string) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [url]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}

--- a/apps/edumatch/app/admin/users/page.tsx
+++ b/apps/edumatch/app/admin/users/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+
+type UserRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  createdAt: string;
+  roles: string[];
+  hasStudentProfile: boolean;
+  hasTutorProfile: boolean;
+  tutorVerified: boolean;
+  studentGradeLevel: string | null;
+  tutorSubjects: string[];
+  tutorRating: number | null;
+};
+
+export default function UsersPage() {
+  const [search, setSearch] = useState("");
+  const [data, setData] = useState<{ items: UserRow[]; total: number } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (q: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ limit: "50" });
+      if (q) params.set("search", q);
+      const res = await fetch(`/api/admin/users?${params}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(search);
+  }, [load, search]);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-[var(--color-text)]">Users & Tutors</h1>
+            <p className="text-sm text-[var(--color-text-muted)] mt-1">Browse user accounts and profiles.</p>
+          </div>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or email..."
+            className="w-full sm:w-64 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)]"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{error}</div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
+      ) : !data || data.items.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">No users found.</p>
+      ) : (
+        <>
+          <p className="text-xs text-[var(--color-text-muted)] mb-3">{data.total} total</p>
+
+          {/* Mobile cards */}
+          <div className="space-y-3 md:hidden">
+            {data.items.map((u) => (
+              <div key={u.id} className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="min-w-0">
+                    <p className="font-semibold text-[var(--color-text)] truncate">{u.name ?? "-"}</p>
+                    <p className="text-xs text-[var(--color-text-muted)] truncate">{u.email}</p>
+                  </div>
+                  <div className="flex gap-1 shrink-0">
+                    {u.hasStudentProfile && (
+                      <span className="rounded-full bg-blue-500/15 px-1.5 py-0.5 text-[10px] text-blue-400">Student</span>
+                    )}
+                    {u.hasTutorProfile && (
+                      <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] text-emerald-400">Tutor</span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-1 mb-2">
+                  {u.roles.map((r) => (
+                    <span key={r} className="rounded-full bg-[var(--color-surface)] px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)] border border-[var(--color-border)]">
+                      {r}
+                    </span>
+                  ))}
+                </div>
+                <div className="flex items-center justify-between text-xs text-[var(--color-text-muted)]">
+                  <span>
+                    {u.hasTutorProfile ? (
+                      u.tutorVerified ? (
+                        <span className="text-green-400">Verified tutor</span>
+                      ) : (
+                        <span className="text-yellow-400">Unverified tutor</span>
+                      )
+                    ) : null}
+                  </span>
+                  <span>Joined {new Date(u.createdAt).toLocaleDateString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--color-border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Name</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Email</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Roles</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Profiles</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Tutor Status</th>
+                  <th className="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.items.map((u) => (
+                  <tr key={u.id} className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface)]">
+                    <td className="px-3 py-2 text-[var(--color-text)]">{u.name ?? "-"}</td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{u.email}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-wrap gap-1">
+                        {u.roles.map((r) => (
+                          <span key={r} className="rounded-full bg-[var(--color-surface)] px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)] border border-[var(--color-border)]">
+                            {r}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex gap-1">
+                        {u.hasStudentProfile && (
+                          <span className="rounded-full bg-blue-500/15 px-1.5 py-0.5 text-[10px] text-blue-400">Student</span>
+                        )}
+                        {u.hasTutorProfile && (
+                          <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] text-emerald-400">Tutor</span>
+                        )}
+                        {!u.hasStudentProfile && !u.hasTutorProfile && (
+                          <span className="text-[var(--color-text-muted)] text-xs">-</span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {u.hasTutorProfile ? (
+                        u.tutorVerified ? (
+                          <span className="rounded-full bg-green-500/15 px-1.5 py-0.5 text-[10px] text-green-400">Verified</span>
+                        ) : (
+                          <span className="rounded-full bg-yellow-500/15 px-1.5 py-0.5 text-[10px] text-yellow-400">Unverified</span>
+                        )
+                      ) : (
+                        <span className="text-[var(--color-text-muted)] text-xs">-</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--color-text-muted)]">{new Date(u.createdAt).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/edumatch/app/api/admin/audit/route.ts
+++ b/apps/edumatch/app/api/admin/audit/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { listEduAuditEvents } from "@/lib/server/audit";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole("ADMIN");
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0");
+    const entity = searchParams.get("entity") || undefined;
+    const entityId = searchParams.get("entityId") || undefined;
+    const action = searchParams.get("action") || undefined;
+    const actorId = searchParams.get("actorId") || undefined;
+    const events = await listEduAuditEvents({ entity, entityId, action, actorId, limit, offset });
+    return NextResponse.json({ events, total: events.length });
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/audit", error);
+    }
+    return serverError("admin/audit", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/bookings/route.ts
+++ b/apps/edumatch/app/api/admin/bookings/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { listAdminBookings } from "@/lib/server/admin-queries";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole("ADMIN");
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0");
+    const status = searchParams.get("status") || undefined;
+    const studentId = searchParams.get("studentId") || undefined;
+    const tutorId = searchParams.get("tutorId") || undefined;
+    const data = await listAdminBookings({ limit, offset, status, studentId, tutorId });
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/bookings", error);
+    }
+    return serverError("admin/bookings", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/disputes/[id]/route.ts
+++ b/apps/edumatch/app/api/admin/disputes/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, badRequest, serverError } from "@/lib/server";
+import { resolveDispute } from "@/lib/server/bookings";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { user } = await requireRole("ADMIN");
+    const { id: bookingId } = await params;
+    const body = (await req.json().catch(() => null)) as {
+      resolution?: string;
+      reason?: string;
+      refundCents?: number;
+    } | null;
+
+    if (!body?.resolution || !body?.reason) {
+      return badRequest("resolution and reason are required");
+    }
+    if (!["REFUND", "NO_REFUND"].includes(body.resolution)) {
+      return badRequest("resolution must be REFUND or NO_REFUND");
+    }
+
+    const booking = await resolveDispute({
+      bookingId,
+      adminId: user.id,
+      resolution: body.resolution as "REFUND" | "NO_REFUND",
+      reason: body.reason,
+      refundCents: body.refundCents,
+    });
+
+    return NextResponse.json({ ok: true, booking });
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/disputes/[id]", error);
+    }
+    if (error instanceof Error && error.name === "BookingTransitionError") {
+      return badRequest(error.message);
+    }
+    return serverError("admin/disputes/[id]", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/disputes/route.ts
+++ b/apps/edumatch/app/api/admin/disputes/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { listAdminDisputes } from "@/lib/server/admin-queries";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole("ADMIN");
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0");
+    const data = await listAdminDisputes({ limit, offset });
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/disputes", error);
+    }
+    return serverError("admin/disputes", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/inquiries/route.ts
+++ b/apps/edumatch/app/api/admin/inquiries/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { listAdminInquiries } from "@/lib/server/admin-queries";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole("ADMIN");
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0");
+    const status = searchParams.get("status") || undefined;
+    const moderationOutcome = searchParams.get("moderationOutcome") || undefined;
+    const subject = searchParams.get("subject") || undefined;
+    const data = await listAdminInquiries({ limit, offset, status, moderationOutcome, subject });
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/inquiries", error);
+    }
+    return serverError("admin/inquiries", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/overview/route.ts
+++ b/apps/edumatch/app/api/admin/overview/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { getAdminOverviewStats } from "@/lib/server/admin-queries";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    await requireRole("ADMIN");
+    const stats = await getAdminOverviewStats();
+    return NextResponse.json(stats);
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/overview", error);
+    }
+    return serverError("admin/overview", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/transactions/route.ts
+++ b/apps/edumatch/app/api/admin/transactions/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { listAdminTransactions, getAdminWallets } from "@/lib/server/admin-queries";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole("ADMIN");
+    const { searchParams } = new URL(req.url);
+    const view = searchParams.get("view"); // "wallets" for wallet overview
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0");
+
+    if (view === "wallets") {
+      const data = await getAdminWallets({ limit, offset });
+      return NextResponse.json(data);
+    }
+
+    const type = searchParams.get("type") || undefined;
+    const tutorId = searchParams.get("tutorId") || undefined;
+    const bookingId = searchParams.get("bookingId") || undefined;
+    const data = await listAdminTransactions({ limit, offset, type, tutorId, bookingId });
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/transactions", error);
+    }
+    return serverError("admin/transactions", error);
+  }
+}

--- a/apps/edumatch/app/api/admin/users/route.ts
+++ b/apps/edumatch/app/api/admin/users/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/server/profiles";
+import { handleEduError, serverError } from "@/lib/server";
+import { listAdminUsers } from "@/lib/server/admin-queries";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole("ADMIN");
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0");
+    const search = searchParams.get("search") || undefined;
+    const data = await listAdminUsers({ limit, offset, search });
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("admin/users", error);
+    }
+    return serverError("admin/users", error);
+  }
+}

--- a/apps/edumatch/lib/server/admin-queries.ts
+++ b/apps/edumatch/lib/server/admin-queries.ts
@@ -1,0 +1,329 @@
+import { prisma } from "@asafarim/db";
+
+export type PaginationOpts = {
+  limit?: number;
+  offset?: number;
+};
+
+export async function getAdminOverviewStats() {
+  const [
+    openVerifications,
+    disputedBookings,
+    recentBookings,
+    recentInquiries,
+    refusedInquiries,
+    recentTransactions,
+    recentAuditEvents,
+    totalStudents,
+    totalTutors,
+  ] = await Promise.all([
+    prisma.eduTutorVerification.count({
+      where: { status: { in: ["PENDING", "NEEDS_CHANGES"] } },
+    }),
+    prisma.eduBooking.count({ where: { status: "DISPUTED" } }),
+    prisma.eduBooking.findMany({
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        status: true,
+        scheduledAt: true,
+        createdAt: true,
+        student: { select: { name: true, email: true } },
+        tutor: { select: { name: true, email: true } },
+      },
+    }),
+    prisma.eduInquiry.findMany({
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        subject: true,
+        status: true,
+        moderationOutcome: true,
+        createdAt: true,
+        student: { select: { name: true, email: true } },
+      },
+    }),
+    prisma.eduInquiry.count({
+      where: { moderationOutcome: "REFUSE" },
+    }),
+    prisma.eduTransaction.findMany({
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        type: true,
+        grossCents: true,
+        netCents: true,
+        currency: true,
+        createdAt: true,
+      },
+    }),
+    prisma.eduAuditEvent.findMany({
+      take: 8,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        action: true,
+        entity: true,
+        entityId: true,
+        actorRole: true,
+        createdAt: true,
+        actor: { select: { name: true, email: true } },
+      },
+    }),
+    prisma.eduStudentProfile.count(),
+    prisma.eduTutorProfile.count(),
+  ]);
+
+  return {
+    openVerifications,
+    disputedBookings,
+    refusedInquiries,
+    totalStudents,
+    totalTutors,
+    recentBookings,
+    recentInquiries,
+    recentTransactions,
+    recentAuditEvents,
+  };
+}
+
+export async function listAdminBookings(opts: PaginationOpts & {
+  status?: string;
+  studentId?: string;
+  tutorId?: string;
+} = {}) {
+  const { limit = 50, offset = 0, status, studentId, tutorId } = opts;
+  const [items, total] = await Promise.all([
+    prisma.eduBooking.findMany({
+      where: {
+        ...(status ? { status } : {}),
+        ...(studentId ? { studentId } : {}),
+        ...(tutorId ? { tutorId } : {}),
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        quoteId: true,
+        status: true,
+        mode: true,
+        scheduledAt: true,
+        durationMinutes: true,
+        completedAt: true,
+        cancelledAt: true,
+        cancellationReason: true,
+        stripePaymentIntentId: true,
+        createdAt: true,
+        student: { select: { id: true, name: true, email: true } },
+        tutor: { select: { id: true, name: true, email: true } },
+      },
+    }),
+    prisma.eduBooking.count({
+      where: {
+        ...(status ? { status } : {}),
+        ...(studentId ? { studentId } : {}),
+        ...(tutorId ? { tutorId } : {}),
+      },
+    }),
+  ]);
+  return { items, total };
+}
+
+export async function listAdminDisputes(opts: PaginationOpts = {}) {
+  const { limit = 50, offset = 0 } = opts;
+  const [items, total] = await Promise.all([
+    prisma.eduBooking.findMany({
+      where: { status: "DISPUTED" },
+      orderBy: { updatedAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        quoteId: true,
+        status: true,
+        mode: true,
+        scheduledAt: true,
+        cancelledAt: true,
+        cancellationReason: true,
+        stripePaymentIntentId: true,
+        createdAt: true,
+        updatedAt: true,
+        student: { select: { id: true, name: true, email: true } },
+        tutor: { select: { id: true, name: true, email: true } },
+        transactions: {
+          select: { id: true, type: true, grossCents: true, netCents: true, createdAt: true },
+        },
+      },
+    }),
+    prisma.eduBooking.count({ where: { status: "DISPUTED" } }),
+  ]);
+  return { items, total };
+}
+
+export async function listAdminTransactions(opts: PaginationOpts & {
+  type?: string;
+  tutorId?: string;
+  bookingId?: string;
+} = {}) {
+  const { limit = 50, offset = 0, type, tutorId, bookingId } = opts;
+  const [items, total] = await Promise.all([
+    prisma.eduTransaction.findMany({
+      where: {
+        ...(type ? { type } : {}),
+        ...(tutorId ? { tutorId } : {}),
+        ...(bookingId ? { bookingId } : {}),
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        bookingId: true,
+        type: true,
+        grossCents: true,
+        platformFeeCents: true,
+        netCents: true,
+        currency: true,
+        stripeChargeId: true,
+        stripePayoutId: true,
+        createdAt: true,
+        tutor: { select: { id: true, name: true, email: true } },
+      },
+    }),
+    prisma.eduTransaction.count({
+      where: {
+        ...(type ? { type } : {}),
+        ...(tutorId ? { tutorId } : {}),
+        ...(bookingId ? { bookingId } : {}),
+      },
+    }),
+  ]);
+  return { items, total };
+}
+
+export async function listAdminUsers(opts: PaginationOpts & {
+  search?: string;
+} = {}) {
+  const { limit = 50, offset = 0, search } = opts;
+  const where = search
+    ? {
+        OR: [
+          { name: { contains: search, mode: "insensitive" as const } },
+          { email: { contains: search, mode: "insensitive" as const } },
+        ],
+      }
+    : {};
+
+  const [items, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        createdAt: true,
+        userRoles: {
+          select: { role: { select: { name: true } } },
+        },
+        eduStudentProfile: { select: { id: true, gradeLevel: true } },
+        eduTutorProfile: {
+          select: {
+            id: true,
+            verifiedAt: true,
+            subjectsTaught: true,
+            ratingAvg: true,
+          },
+        },
+      },
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  return {
+    items: items.map((u) => ({
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      createdAt: u.createdAt,
+      roles: u.userRoles.map((ur) => ur.role.name),
+      hasStudentProfile: !!u.eduStudentProfile,
+      hasTutorProfile: !!u.eduTutorProfile,
+      tutorVerified: u.eduTutorProfile?.verifiedAt != null,
+      studentGradeLevel: u.eduStudentProfile?.gradeLevel ?? null,
+      tutorSubjects: u.eduTutorProfile?.subjectsTaught ?? [],
+      tutorRating: u.eduTutorProfile?.ratingAvg ?? null,
+    })),
+    total,
+  };
+}
+
+export async function listAdminInquiries(opts: PaginationOpts & {
+  status?: string;
+  moderationOutcome?: string;
+  subject?: string;
+} = {}) {
+  const { limit = 50, offset = 0, status, moderationOutcome, subject } = opts;
+  const [items, total] = await Promise.all([
+    prisma.eduInquiry.findMany({
+      where: {
+        ...(status ? { status } : {}),
+        ...(moderationOutcome ? { moderationOutcome } : {}),
+        ...(subject ? { subject: { contains: subject, mode: "insensitive" as const } } : {}),
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        subject: true,
+        gradeLevel: true,
+        status: true,
+        moderationOutcome: true,
+        moderationCategory: true,
+        createdAt: true,
+        student: { select: { id: true, name: true, email: true } },
+        aiResponses: {
+          take: 1,
+          orderBy: { createdAt: "desc" },
+          select: { modelUsed: true, moderationOutcome: true },
+        },
+      },
+    }),
+    prisma.eduInquiry.count({
+      where: {
+        ...(status ? { status } : {}),
+        ...(moderationOutcome ? { moderationOutcome } : {}),
+        ...(subject ? { subject: { contains: subject, mode: "insensitive" as const } } : {}),
+      },
+    }),
+  ]);
+  return { items, total };
+}
+
+export async function getAdminWallets(opts: PaginationOpts = {}) {
+  const { limit = 50, offset = 0 } = opts;
+  const [items, total] = await Promise.all([
+    prisma.eduWallet.findMany({
+      orderBy: { updatedAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        tutorId: true,
+        balanceCents: true,
+        pendingCents: true,
+        lastPayoutAt: true,
+        currency: true,
+        tutor: { select: { name: true, email: true } },
+      },
+    }),
+    prisma.eduWallet.count(),
+  ]);
+  return { items, total };
+}


### PR DESCRIPTION
…ts and activity feeds (#119)

- Convert admin overview from static section grid to live dashboard with real-time data
- Add useAdminFetch hook for client-side admin API calls
- Display stat cards for open verifications, disputes, refused inquiries, and user counts
- Show recent bookings, inquiries, transactions, and audit events with status badges
- Add /api/admin/overview endpoint to README API surface
- Enable all admin nav items (