### PR TITLE
feat(edumatch): add emoji reactions to verification messages

### DIFF
--- a/apps/edumatch/app/admin/tutor-verifications/page.tsx
+++ b/apps/edumatch/app/admin/tutor-verifications/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { useTranslation } from "@asafarim/shared-i18n";
 import MessageAttachments, { type AttachmentView } from "@/components/MessageAttachments";
 import VerificationComposer, { type StoredAttachment } from "@/components/VerificationComposer";
+import EmojiReactionBar, { type MessageReactions } from "@/components/EmojiReactionBar";
 
 type Review = {
   id: string;
@@ -21,6 +23,7 @@ type ThreadMessage = {
   senderName: string | null;
   body: string;
   attachments: AttachmentView[];
+  reactions: MessageReactions;
   createdAt: string;
 };
 
@@ -44,6 +47,7 @@ const STATUS_BADGE: Record<string, string> = {
 
 export default function AdminTutorVerificationsPage() {
   const { t } = useTranslation();
+  const { data: session } = useSession();
   const [rows, setRows] = useState<TutorRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -149,6 +153,7 @@ export default function AdminTutorVerificationsPage() {
               row={r}
               busy={busyId === r.tutorId}
               onSetStatus={setStatus}
+              currentUserId={session?.user?.id ?? null}
             />
           ))}
         </div>
@@ -161,6 +166,7 @@ function TutorRowCard({
   row,
   busy,
   onSetStatus,
+  currentUserId,
 }: {
   row: TutorRow;
   busy: boolean;
@@ -169,6 +175,7 @@ function TutorRowCard({
     status: string,
     extra?: { tutorMessage?: string; adminNotes?: string },
   ) => Promise<void>;
+  currentUserId: string | null;
 }) {
   const { t } = useTranslation();
   const [needsMsg, setNeedsMsg] = useState("");
@@ -367,6 +374,14 @@ function TutorRowCard({
                           <div className="whitespace-pre-wrap break-words">{m.body}</div>
                         )}
                         <MessageAttachments attachments={m.attachments} />
+                        {currentUserId && (
+                          <EmojiReactionBar
+                            messageId={m.id}
+                            reactions={m.reactions ?? {}}
+                            currentUserId={currentUserId}
+                            pickerAbove
+                          />
+                        )}
                       </div>
                     </div>
                   );

--- a/apps/edumatch/app/api/verification/messages/[id]/reactions/route.ts
+++ b/apps/edumatch/app/api/verification/messages/[id]/reactions/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleEduError, badRequest, serverError } from "@/lib/server";
+import { requireRole } from "@/lib/server/profiles";
+import {
+  toggleReaction,
+  SUPPORTED_EMOJIS,
+  type SupportedEmoji,
+} from "@/lib/server/verification-messages";
+import { prisma } from "@asafarim/db";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/verification/messages/:id/reactions
+ * Body: { emoji: SupportedEmoji }
+ *
+ * Toggles the calling user's reaction on the given message. Both admins and
+ * tutors may react; the message must belong to a thread the caller participates
+ * in (tutor is the caller, or caller is ADMIN).
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { user, roles } = await requireRole("ADMIN", "TUTOR");
+    const { id: messageId } = await params;
+
+    const body = (await req.json().catch(() => null)) as
+      | { emoji?: unknown }
+      | null;
+    const emoji = body?.emoji;
+    if (
+      typeof emoji !== "string" ||
+      !(SUPPORTED_EMOJIS as readonly string[]).includes(emoji)
+    ) {
+      return badRequest(`emoji must be one of: ${SUPPORTED_EMOJIS.join(", ")}`);
+    }
+
+    const msg = await prisma.eduVerificationMessage.findUnique({
+      where: { id: messageId },
+      select: { tutorId: true },
+    });
+    if (!msg) {
+      return NextResponse.json({ error: "Message not found" }, { status: 404 });
+    }
+
+    const isAdmin = roles.includes("ADMIN");
+    const isTutor = msg.tutorId === user.id;
+    if (!isAdmin && !isTutor) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const reactions = await toggleReaction(
+      messageId,
+      user.id,
+      emoji as SupportedEmoji,
+    );
+    return NextResponse.json({ ok: true, reactions });
+  } catch (error) {
+    if (error instanceof Error && error.name === "EduAuthError") {
+      return handleEduError("verification/messages/reactions", error);
+    }
+    return serverError("verification/messages/reactions", error);
+  }
+}

--- a/apps/edumatch/app/tutor/verification/page.tsx
+++ b/apps/edumatch/app/tutor/verification/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { useTranslation } from "@asafarim/shared-i18n";
 import MessageAttachments, { type AttachmentView } from "@/components/MessageAttachments";
 import VerificationComposer, { type StoredAttachment } from "@/components/VerificationComposer";
+import EmojiReactionBar, { type MessageReactions } from "@/components/EmojiReactionBar";
 
 type ThreadRole = "ADMIN" | "TUTOR";
 
@@ -14,6 +15,7 @@ type Message = {
   senderName: string | null;
   body: string;
   attachments: AttachmentView[];
+  reactions: MessageReactions;
   createdAt: string;
 };
 
@@ -39,7 +41,7 @@ function fmt(ts: string): string {
 
 export default function TutorVerificationPage() {
   const { t } = useTranslation();
-  const { status: authStatus } = useSession();
+  const { data: session, status: authStatus } = useSession();
   const [state, setState] = useState<VerificationState | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -132,6 +134,13 @@ export default function TutorVerificationPage() {
                     </div>
                     {m.body && <div className="whitespace-pre-wrap break-words">{m.body}</div>}
                     <MessageAttachments attachments={m.attachments} />
+                    {session?.user?.id && (
+                      <EmojiReactionBar
+                        messageId={m.id}
+                        reactions={m.reactions ?? {}}
+                        currentUserId={session.user.id}
+                      />
+                    )}
                   </div>
                 </div>
               );

--- a/apps/edumatch/components/EmojiReactionBar.tsx
+++ b/apps/edumatch/components/EmojiReactionBar.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+
+export type MessageReactions = Partial<
+  Record<
+    "thumbsup" | "thumbsdown" | "check" | "question" | "eyes" | "tada",
+    string[]
+  >
+>;
+
+type SupportedEmoji = keyof MessageReactions;
+
+const EMOJI_MAP: Record<SupportedEmoji, string> = {
+  thumbsup: "👍",
+  thumbsdown: "👎",
+  check: "✅",
+  question: "❓",
+  eyes: "👀",
+  tada: "🎉",
+};
+
+const ALL_EMOJIS = Object.keys(EMOJI_MAP) as SupportedEmoji[];
+
+interface Props {
+  messageId: string;
+  reactions: MessageReactions;
+  currentUserId: string;
+  /** If true, picker opens above the bar (for messages near the bottom of the thread). */
+  pickerAbove?: boolean;
+}
+
+export default function EmojiReactionBar({
+  messageId,
+  reactions,
+  currentUserId,
+  pickerAbove = false,
+}: Props) {
+  const [local, setLocal] = useState<MessageReactions>(reactions);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [busy, setBusy] = useState<SupportedEmoji | null>(null);
+
+  async function toggle(emoji: SupportedEmoji) {
+    if (busy) return;
+    setBusy(emoji);
+    setPickerOpen(false);
+
+    // Optimistic update
+    const prev = local[emoji] ?? [];
+    const alreadyReacted = prev.includes(currentUserId);
+    const next = alreadyReacted
+      ? prev.filter((id) => id !== currentUserId)
+      : [...prev, currentUserId];
+    setLocal((r) => {
+      const updated = { ...r };
+      if (next.length === 0) {
+        delete updated[emoji];
+      } else {
+        updated[emoji] = next;
+      }
+      return updated;
+    });
+
+    try {
+      const res = await fetch(
+        `/api/verification/messages/${messageId}/reactions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ emoji }),
+        },
+      );
+      if (res.ok) {
+        const data = (await res.json()) as { reactions: MessageReactions };
+        setLocal(data.reactions);
+      } else {
+        // Revert on failure
+        setLocal(reactions);
+      }
+    } catch {
+      setLocal(reactions);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const activeEmojis = ALL_EMOJIS.filter(
+    (e) => local[e] && (local[e]?.length ?? 0) > 0,
+  );
+
+  return (
+    <div className="relative mt-1 flex flex-wrap items-center gap-1">
+      {/* Existing reaction chips */}
+      {activeEmojis.map((emoji) => {
+        const users = local[emoji] ?? [];
+        const mine = users.includes(currentUserId);
+        return (
+          <button
+            key={emoji}
+            onClick={() => void toggle(emoji)}
+            disabled={busy === emoji}
+            aria-label={`${EMOJI_MAP[emoji]} ${users.length}${mine ? " (you reacted)" : ""}`}
+            aria-pressed={mine}
+            className={`flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-xs transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] ${
+              mine
+                ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
+                : "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-panel)]"
+            } disabled:opacity-50`}
+          >
+            <span aria-hidden="true">{EMOJI_MAP[emoji]}</span>
+            <span>{users.length}</span>
+          </button>
+        );
+      })}
+
+      {/* Add-reaction button */}
+      <div className="relative">
+        <button
+          onClick={() => setPickerOpen((o) => !o)}
+          aria-label="Add reaction"
+          aria-expanded={pickerOpen}
+          aria-haspopup="true"
+          className="flex h-5 w-5 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-panel)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)]"
+        >
+          +
+        </button>
+
+        {pickerOpen && (
+          <div
+            role="menu"
+            aria-label="Emoji picker"
+            className={`absolute z-10 flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-1.5 shadow-lg ${
+              pickerAbove ? "bottom-7 left-0" : "left-0 top-7"
+            }`}
+          >
+            {ALL_EMOJIS.map((emoji) => (
+              <button
+                key={emoji}
+                role="menuitem"
+                onClick={() => void toggle(emoji)}
+                disabled={busy === emoji}
+                aria-label={emoji}
+                className="rounded p-1 text-base transition-colors hover:bg-[var(--color-surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] disabled:opacity-50"
+              >
+                {EMOJI_MAP[emoji]}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/edumatch/lib/server/verification-messages.ts
+++ b/apps/edumatch/lib/server/verification-messages.ts
@@ -26,6 +26,18 @@ export type StoredAttachment = {
   sizeBytes: number;
 };
 
+export const SUPPORTED_EMOJIS = [
+  "thumbsup",
+  "thumbsdown",
+  "check",
+  "question",
+  "eyes",
+  "tada",
+] as const;
+export type SupportedEmoji = (typeof SUPPORTED_EMOJIS)[number];
+
+export type MessageReactions = Partial<Record<SupportedEmoji, string[]>>;
+
 export type VerificationMessageView = {
   id: string;
   senderRole: ThreadRole;
@@ -33,6 +45,7 @@ export type VerificationMessageView = {
   senderName: string | null;
   body: string;
   attachments: AttachmentView[];
+  reactions: MessageReactions;
   readAt: string | null;
   createdAt: string;
 };
@@ -154,6 +167,7 @@ export async function listVerificationThread(
       senderName: m.sender?.name ?? null,
       body: m.body,
       attachments: await signAttachments(m.attachments),
+      reactions: parseReactions(m.reactions),
       readAt: m.readAt ? m.readAt.toISOString() : null,
       createdAt: m.createdAt.toISOString(),
     })),
@@ -182,4 +196,49 @@ export async function countUnreadForAdmin(tutorId: string): Promise<number> {
   return prisma.eduVerificationMessage.count({
     where: { tutorId, senderRole: "TUTOR", readAt: null },
   });
+}
+
+function parseReactions(raw: unknown): MessageReactions {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const result: MessageReactions = {};
+  for (const emoji of SUPPORTED_EMOJIS) {
+    const val = (raw as Record<string, unknown>)[emoji];
+    if (Array.isArray(val)) {
+      result[emoji] = val.filter((v): v is string => typeof v === "string");
+    }
+  }
+  return result;
+}
+
+export async function toggleReaction(
+  messageId: string,
+  userId: string,
+  emoji: SupportedEmoji,
+): Promise<MessageReactions> {
+  const msg = await prisma.eduVerificationMessage.findUniqueOrThrow({
+    where: { id: messageId },
+    select: { reactions: true },
+  });
+
+  const reactions = parseReactions(msg.reactions);
+  const current = reactions[emoji] ?? [];
+  const alreadyReacted = current.includes(userId);
+
+  if (alreadyReacted) {
+    const updated = current.filter((id) => id !== userId);
+    if (updated.length === 0) {
+      delete reactions[emoji];
+    } else {
+      reactions[emoji] = updated;
+    }
+  } else {
+    reactions[emoji] = [...current, userId];
+  }
+
+  await prisma.eduVerificationMessage.update({
+    where: { id: messageId },
+    data: { reactions: reactions as unknown as Prisma.InputJsonValue },
+  });
+
+  return reactions;
 }

--- a/packages/db/prisma/migrations/20260530180000_verification_message_reactions/migration.sql
+++ b/packages/db/prisma/migrations/20260530180000_verification_message_reactions/migration.sql
@@ -1,0 +1,3 @@
+-- Add reactions JSONB column to EduVerificationMessage.
+-- Stores { [emoji]: userId[] } where emoji is one of the supported set.
+ALTER TABLE "EduVerificationMessage" ADD COLUMN "reactions" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1145,6 +1145,9 @@ model EduVerificationMessage {
   // storage object keys scoped to the uploader; URLs are signed on read because
   // the bucket is private.
   attachments Json?
+  // Emoji reactions: { [emoji]: userId[] } — emoji keys are restricted to the
+  // supported set (thumbsup, thumbsdown, check, question, eyes, tada).
+  reactions  Json?
   readAt     DateTime?
   createdAt  DateTime  @default(now())
 


### PR DESCRIPTION
Closes #136

## Summary
- **Schema**: adds `reactions JSONB` column to `EduVerificationMessage` (migration `20260530180000_verification_message_reactions`)
- **Server lib** (`verification-messages.ts`): exports `SUPPORTED_EMOJIS`, `SupportedEmoji`, `MessageReactions`, and `toggleReaction(messageId, userId, emoji)` — stores reactions as `{ [emoji]: userId[] }`, toggling the caller's entry on/off
- **API** (`POST /api/verification/messages/[id]/reactions`): shared for admins and tutors; validates the emoji, checks the caller is a thread participant, delegates to `toggleReaction`
- **`EmojiReactionBar` component**: renders existing reaction chips with counts, highlights the current user's own reaction (`aria-pressed`), and shows a `+` button that opens a keyboard-navigable emoji picker; updates are optimistic with server-side reconciliation
- **Pages**: `EmojiReactionBar` integrated beneath each message bubble in both the tutor verification page and the admin conversation thread

## Test plan
- [ ] Tutor opens verification thread → reaction bar appears beneath each message
- [ ] Click `+` → picker shows all 6 emoji (👍 👎 ✅ ❓ 👀 🎉)
- [ ] Click an emoji → count chip appears, highlighted for current user
- [ ] Click the same emoji chip again → reaction is removed
- [ ] Reload page → reactions persist (stored in DB)
- [ ] Admin opens thread in `/admin/tutor-verifications` → same behaviour, picker opens above
- [ ] Keyboard: tab to `+`, Enter to open picker, tab through emoji, Enter to react
- [ ] Attempt to react to a message in a thread you don't participate in → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #137