### PR TITLE
feat(marketing-content): connect to database and add campaign logging

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -14,6 +14,13 @@
       "runtimeArgs": ["--filter", "edumatch", "dev"],
       "port": 3005,
       "autoPort": false
+    },
+    {
+      "name": "marketing-content",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "marketing-content", "dev"],
+      "port": 3004,
+      "autoPort": false
     }
   ]
 }

--- a/apps/marketing-content/app/campaigns/NewCampaignButton.tsx
+++ b/apps/marketing-content/app/campaigns/NewCampaignButton.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useId, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createCampaign } from "./actions";
+
+const CHANNELS = ["seo", "email", "paid", "social", "partner"] as const;
+const STATUSES = ["scheduled", "live", "paused", "ended"] as const;
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function inputCls(hasError: boolean) {
+  return `w-full rounded-lg border ${hasError ? "border-rose-500" : "border-[var(--color-border)]"} bg-[var(--color-surface)]/60 px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-subtle)] focus:border-[var(--color-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/20 transition-colors`;
+}
+
+function Field({
+  label, id, error, children,
+}: {
+  label: string; id: string; error?: string; children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-xs font-medium text-[var(--color-text-muted)]">{label}</label>
+      {children}
+      {error && <p className="text-[11px] text-rose-400">{error}</p>}
+    </div>
+  );
+}
+
+export function NewCampaignButton() {
+  const router = useRouter();
+  const uid = useId();
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    name: "",
+    channel: "paid",
+    status: "scheduled",
+    budgetDollars: "",
+    startedAt: todayIso(),
+    owner: "",
+  });
+
+  const set = (k: keyof typeof form) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+      setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  function close() {
+    setOpen(false);
+    setErrors({});
+    setFormError(null);
+    setForm({ name: "", channel: "paid", status: "scheduled", budgetDollars: "", startedAt: todayIso(), owner: "" });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    setSaving(true);
+    const res = await createCampaign({
+      name: form.name,
+      channel: form.channel,
+      status: form.status,
+      budgetDollars: form.budgetDollars,
+      startedAt: form.startedAt,
+      owner: form.owner,
+    });
+    setSaving(false);
+    if (!res.ok) {
+      setErrors(res.fieldErrors ?? {});
+      setFormError(res.error);
+      return;
+    }
+    close();
+    router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-lg bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-white hover:brightness-110"
+      >
+        + New campaign
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
+            onClick={close}
+            aria-hidden="true"
+          />
+          <aside
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`${uid}-title`}
+            className="fixed inset-y-0 right-0 z-50 flex w-full max-w-[480px] flex-col border-l border-[var(--color-border-strong)] bg-[var(--color-bg)] shadow-2xl"
+            style={{ animation: "slideInRight 0.22s cubic-bezier(.16,1,.3,1) both" }}
+          >
+            <style>{`
+              @keyframes slideInRight {
+                from { transform: translateX(100%); opacity: 0; }
+                to   { transform: translateX(0);    opacity: 1; }
+              }
+            `}</style>
+
+            <div className="flex items-center justify-between border-b border-[var(--color-border)] px-6 py-4">
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--color-text-subtle)]">Campaign</p>
+                <h2 id={`${uid}-title`} className="text-base font-semibold text-[var(--color-text)]">New Campaign</h2>
+              </div>
+              <button
+                type="button"
+                onClick={close}
+                aria-label="Close"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--color-text-muted)] hover:bg-white/[0.06] hover:text-[var(--color-text)] transition-colors"
+              >
+                <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4" aria-hidden="true">
+                  <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-y-auto">
+              <div className="flex-1 space-y-5 px-6 py-5">
+                {formError && (
+                  <div role="alert" className="rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-300">
+                    {formError}
+                  </div>
+                )}
+
+                <Field label="Campaign name" id={`${uid}-name`} error={errors.name}>
+                  <input id={`${uid}-name`} type="text" placeholder="e.g. Q3 Growth — Ops Hub"
+                    value={form.name} onChange={set("name")} className={inputCls(!!errors.name)} />
+                </Field>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <Field label="Channel" id={`${uid}-channel`} error={errors.channel}>
+                    <select id={`${uid}-channel`} value={form.channel} onChange={set("channel")} className={inputCls(!!errors.channel)}>
+                      {CHANNELS.map((ch) => <option key={ch} value={ch}>{ch}</option>)}
+                    </select>
+                  </Field>
+                  <Field label="Status" id={`${uid}-status`} error={errors.status}>
+                    <select id={`${uid}-status`} value={form.status} onChange={set("status")} className={inputCls(!!errors.status)}>
+                      {STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+                    </select>
+                  </Field>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <Field label="Budget (USD)" id={`${uid}-budget`} error={errors.budgetDollars}>
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-text-subtle)] text-sm">$</span>
+                      <input id={`${uid}-budget`} type="number" min="0" step="0.01" placeholder="0.00"
+                        value={form.budgetDollars} onChange={set("budgetDollars")} className={`${inputCls(!!errors.budgetDollars)} pl-7`} />
+                    </div>
+                  </Field>
+                  <Field label="Start date" id={`${uid}-start`} error={errors.startedAt}>
+                    <input id={`${uid}-start`} type="date" max={todayIso()}
+                      value={form.startedAt} onChange={set("startedAt")} className={inputCls(!!errors.startedAt)} />
+                  </Field>
+                </div>
+
+                <Field label="Owner (optional)" id={`${uid}-owner`}>
+                  <input id={`${uid}-owner`} type="text" placeholder="Defaults to your name"
+                    value={form.owner} onChange={set("owner")} className={inputCls(false)} />
+                </Field>
+              </div>
+
+              <div className="border-t border-[var(--color-border)] px-6 py-4 flex gap-3">
+                <button type="button" onClick={close}
+                  className="flex-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2.5 text-sm font-medium text-[var(--color-text-muted)] hover:bg-white/[0.04] hover:text-[var(--color-text)] transition-colors">
+                  Cancel
+                </button>
+                <button type="submit" disabled={saving}
+                  className="flex-1 rounded-lg bg-gradient-to-r from-rose-500 to-amber-500 px-4 py-2.5 text-sm font-semibold text-white shadow-lg hover:opacity-90 transition-opacity disabled:opacity-60">
+                  {saving ? "Creating…" : "Create Campaign"}
+                </button>
+              </div>
+            </form>
+          </aside>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/marketing-content/app/campaigns/[id]/CampaignDetail.tsx
+++ b/apps/marketing-content/app/campaigns/[id]/CampaignDetail.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useCallback, useId } from "react";
 import Link from "next/link";
-import type { Campaign, PerformanceEntry } from "@/lib/demo-data";
+import type {
+  CampaignView as Campaign,
+  PerformanceEntryView as PerformanceEntry,
+} from "@/lib/campaigns";
+import { logPerformanceEntry } from "../actions";
 import { StatusBadge } from "@/components/StatusBadge";
 import { formatMoney, formatNumber, formatPercent, formatCompact } from "@/lib/format";
 
@@ -165,12 +169,11 @@ function PerformanceChart({ entries, metric }: ChartProps) {
 
 interface LogModalProps {
   campaignId: string;
-  owner: string;
   onClose: () => void;
   onSave: (entry: PerformanceEntry) => void;
 }
 
-function LogEntryModal({ campaignId, owner, onClose, onSave }: LogModalProps) {
+function LogEntryModal({ campaignId, onClose, onSave }: LogModalProps) {
   const uid = useId();
   const [form, setForm] = useState({
     weekOf: todayIso(),
@@ -181,6 +184,7 @@ function LogEntryModal({ campaignId, owner, onClose, onSave }: LogModalProps) {
     notes: "",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const set = (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
@@ -196,29 +200,29 @@ function LogEntryModal({ campaignId, owner, onClose, onSave }: LogModalProps) {
     return errs;
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    setFormError(null);
     const errs = validate();
     if (Object.keys(errs).length) { setErrors(errs); return; }
     setSaving(true);
-    // Simulate async save
-    setTimeout(() => {
-      const entry: PerformanceEntry = {
-        id: `pe-${campaignId}-${Date.now()}`,
-        campaignId,
-        weekOf: form.weekOf,
-        impressions: Math.round(Number(form.impressions)),
-        clicks: Math.round(Number(form.clicks)),
-        conversions: Math.round(Number(form.conversions)),
-        spentCents: Math.round(Number(form.spentDollars) * 100),
-        notes: form.notes || undefined,
-        loggedBy: owner,
-        loggedAt: new Date().toISOString(),
-      };
-      setSaving(false);
-      onSave(entry);
-      onClose();
-    }, 600);
+    const res = await logPerformanceEntry({
+      campaignId,
+      weekOf: form.weekOf,
+      impressions: form.impressions,
+      clicks: form.clicks,
+      conversions: form.conversions,
+      spentDollars: form.spentDollars,
+      notes: form.notes,
+    });
+    setSaving(false);
+    if (!res.ok) {
+      setErrors(res.fieldErrors ?? {});
+      setFormError(res.error);
+      return;
+    }
+    onSave(res.data);
+    onClose();
   }
 
   // Derived preview KPIs from form values
@@ -279,6 +283,16 @@ function LogEntryModal({ campaignId, owner, onClose, onSave }: LogModalProps) {
         {/* Form */}
         <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1 space-y-5 px-6 py-5">
+
+            {/* Form-level error */}
+            {formError && (
+              <div
+                role="alert"
+                className="rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-300"
+              >
+                {formError}
+              </div>
+            )}
 
             {/* Week selector */}
             <Field label="Week of (reporting period start)" id={`${uid}-week`} error={errors.weekOf}>
@@ -689,7 +703,6 @@ export function CampaignDetail({ campaign, initialEntries }: Props) {
       {showModal && (
         <LogEntryModal
           campaignId={campaign.id}
-          owner={campaign.owner}
           onClose={() => setShowModal(false)}
           onSave={handleSave}
         />

--- a/apps/marketing-content/app/campaigns/[id]/page.tsx
+++ b/apps/marketing-content/app/campaigns/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { campaigns, performanceEntries } from "@/lib/demo-data";
+import { getCampaign, listEntries, getCurrentUserId } from "@/lib/campaigns";
 import { CampaignDetail } from "./CampaignDetail";
 
 export const dynamic = "force-dynamic";
@@ -10,12 +10,12 @@ export default async function CampaignDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const campaign = campaigns.find((c) => c.id === id);
+  const userId = await getCurrentUserId();
+
+  const campaign = await getCampaign(id, userId);
   if (!campaign) notFound();
 
-  const entries = performanceEntries
-    .filter((e) => e.campaignId === id)
-    .sort((a, b) => a.weekOf.localeCompare(b.weekOf));
+  const entries = await listEntries(id, userId);
 
   return <CampaignDetail campaign={campaign} initialEntries={entries} />;
 }

--- a/apps/marketing-content/app/campaigns/actions.ts
+++ b/apps/marketing-content/app/campaigns/actions.ts
@@ -1,0 +1,233 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@asafarim/db";
+import { auth } from "@asafarim/auth";
+import type { CampaignView, PerformanceEntryView } from "@/lib/campaigns";
+
+const CHANNELS = ["seo", "email", "paid", "social", "partner"] as const;
+const STATUSES = ["live", "scheduled", "paused", "ended"] as const;
+
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; fieldErrors?: Record<string, string> };
+
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+/** Parse a value as a non-negative integer; returns null when invalid. */
+function parseCount(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n);
+}
+
+/** Parse a dollar amount into non-negative integer cents; null when invalid. */
+function parseCents(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * 100);
+}
+
+/** Validate a YYYY-MM-DD date that is not in the future. */
+function parsePastDate(value: unknown): Date | null {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const d = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  // Allow today; reject future weeks.
+  const todayEnd = new Date();
+  todayEnd.setUTCHours(23, 59, 59, 999);
+  if (d.getTime() > todayEnd.getTime()) return null;
+  return d;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// ── Inputs ────────────────────────────────────────────────────────────────────
+
+export interface CreateCampaignInput {
+  name: string;
+  channel: string;
+  status: string;
+  budgetDollars: string | number;
+  startedAt: string; // YYYY-MM-DD
+  owner?: string;
+}
+
+export interface LogEntryInput {
+  campaignId: string;
+  weekOf: string; // YYYY-MM-DD
+  impressions: string | number;
+  clicks: string | number;
+  conversions: string | number;
+  spentDollars: string | number;
+  notes?: string;
+}
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+
+export async function createCampaign(
+  input: CreateCampaignInput
+): Promise<ActionResult<CampaignView>> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false, error: "You must be signed in." };
+
+  const fieldErrors: Record<string, string> = {};
+
+  const name = (input.name ?? "").trim();
+  if (!name) fieldErrors.name = "Name is required";
+  else if (name.length > 120) fieldErrors.name = "Keep the name under 120 characters";
+
+  const channel = String(input.channel);
+  if (!CHANNELS.includes(channel as (typeof CHANNELS)[number]))
+    fieldErrors.channel = "Choose a valid channel";
+
+  const status = String(input.status);
+  if (!STATUSES.includes(status as (typeof STATUSES)[number]))
+    fieldErrors.status = "Choose a valid status";
+
+  const budgetCents = parseCents(input.budgetDollars);
+  if (budgetCents === null) fieldErrors.budgetDollars = "Enter a valid budget";
+
+  const startedAt = parsePastDate(input.startedAt);
+  if (!startedAt) fieldErrors.startedAt = "Enter a valid start date (not in the future)";
+
+  if (Object.keys(fieldErrors).length) {
+    return { ok: false, error: "Please fix the highlighted fields.", fieldErrors };
+  }
+
+  const owner = (input.owner ?? "").trim() || session.user?.name || session.user?.email || "You";
+
+  const c = await prisma.marketingCampaign.create({
+    data: {
+      ownerId: userId,
+      name,
+      channel,
+      status,
+      owner,
+      budgetCents: budgetCents!,
+      startedAt: startedAt!,
+      // roll-ups start at zero; recomputed as entries are logged.
+      spentCents: 0,
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+    },
+  });
+
+  revalidatePath("/campaigns");
+
+  return {
+    ok: true,
+    data: {
+      id: c.id,
+      name: c.name,
+      channel: c.channel,
+      status: c.status,
+      owner: c.owner,
+      budgetCents: c.budgetCents,
+      spentCents: c.spentCents,
+      impressions: c.impressions,
+      clicks: c.clicks,
+      conversions: c.conversions,
+      startedAt: isoDate(c.startedAt),
+      isOwn: true,
+      entryCount: 0,
+    },
+  };
+}
+
+export async function logPerformanceEntry(
+  input: LogEntryInput
+): Promise<ActionResult<PerformanceEntryView>> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false, error: "You must be signed in." };
+
+  // The campaign must be visible to the user (shared demo or their own).
+  const campaign = await prisma.marketingCampaign.findFirst({
+    where: { id: input.campaignId, OR: [{ ownerId: null }, { ownerId: userId }] },
+    select: { id: true, ownerId: true },
+  });
+  if (!campaign) return { ok: false, error: "Campaign not found." };
+
+  const fieldErrors: Record<string, string> = {};
+
+  const weekOf = parsePastDate(input.weekOf);
+  if (!weekOf) fieldErrors.weekOf = "Enter a valid week (not in the future)";
+
+  const impressions = parseCount(input.impressions);
+  if (impressions === null) fieldErrors.impressions = "Enter a valid number";
+
+  const clicks = parseCount(input.clicks);
+  if (clicks === null) fieldErrors.clicks = "Enter a valid number";
+
+  const conversions = parseCount(input.conversions);
+  if (conversions === null) fieldErrors.conversions = "Enter a valid number";
+
+  const spentCents = parseCents(input.spentDollars);
+  if (spentCents === null) fieldErrors.spentDollars = "Enter a valid amount";
+
+  const notes = (input.notes ?? "").trim();
+  if (notes.length > 2000) fieldErrors.notes = "Keep notes under 2000 characters";
+
+  if (Object.keys(fieldErrors).length) {
+    return { ok: false, error: "Please fix the highlighted fields.", fieldErrors };
+  }
+
+  const loggedBy = session.user?.name || session.user?.email || "You";
+
+  const entry = await prisma.marketingPerformanceEntry.create({
+    data: {
+      campaignId: campaign.id,
+      weekOf: weekOf!,
+      impressions: impressions!,
+      clicks: clicks!,
+      conversions: conversions!,
+      spentCents: spentCents!,
+      notes: notes || null,
+      loggedBy,
+      loggedById: userId,
+    },
+  });
+
+  // Keep denormalized roll-ups in sync for campaigns the user owns. Shared demo
+  // campaigns keep their seed totals (a user's private entry must not leak into
+  // the global showcase numbers). Full list/detail reconciliation is M2.
+  if (campaign.ownerId === userId) {
+    const agg = await prisma.marketingPerformanceEntry.aggregate({
+      where: { campaignId: campaign.id, loggedById: userId },
+      _sum: { impressions: true, clicks: true, conversions: true, spentCents: true },
+    });
+    await prisma.marketingCampaign.update({
+      where: { id: campaign.id },
+      data: {
+        impressions: agg._sum.impressions ?? 0,
+        clicks: agg._sum.clicks ?? 0,
+        conversions: agg._sum.conversions ?? 0,
+        spentCents: agg._sum.spentCents ?? 0,
+      },
+    });
+  }
+
+  revalidatePath(`/campaigns/${campaign.id}`);
+  revalidatePath("/campaigns");
+
+  return {
+    ok: true,
+    data: {
+      id: entry.id,
+      campaignId: entry.campaignId,
+      weekOf: isoDate(entry.weekOf),
+      impressions: entry.impressions,
+      clicks: entry.clicks,
+      conversions: entry.conversions,
+      spentCents: entry.spentCents,
+      notes: entry.notes ?? undefined,
+      loggedBy: entry.loggedBy,
+      loggedAt: entry.loggedAt.toISOString(),
+    },
+  };
+}

--- a/apps/marketing-content/app/campaigns/page.tsx
+++ b/apps/marketing-content/app/campaigns/page.tsx
@@ -3,11 +3,15 @@ import { SectionHeader } from "@/components/SectionHeader";
 import { StatusBadge } from "@/components/StatusBadge";
 import { KpiCard } from "@/components/KpiCard";
 import { formatMoney, formatNumber, formatPercent } from "@/lib/format";
-import { campaigns, performanceEntries } from "@/lib/demo-data";
+import { listCampaigns, getCurrentUserId } from "@/lib/campaigns";
+import { NewCampaignButton } from "./NewCampaignButton";
 
 export const dynamic = "force-dynamic";
 
-export default function CampaignsPage() {
+export default async function CampaignsPage() {
+  const userId = await getCurrentUserId();
+  const campaigns = await listCampaigns(userId);
+
   const totalBudget = campaigns.reduce((s, c) => s + c.budgetCents, 0);
   const totalSpent = campaigns.reduce((s, c) => s + c.spentCents, 0);
   const totalConversions = campaigns.reduce((s, c) => s + c.conversions, 0);
@@ -15,22 +19,13 @@ export default function CampaignsPage() {
   const cvr = totalClicks ? totalConversions / totalClicks : 0;
   const channelList: Array<"seo" | "email" | "paid" | "social" | "partner"> = ["seo", "email", "paid", "social", "partner"];
 
-  // Count logged entries per campaign
-  const entryCounts = Object.fromEntries(
-    campaigns.map((c) => [c.id, performanceEntries.filter((e) => e.campaignId === c.id).length])
-  );
-
   return (
     <div className="space-y-8">
       <SectionHeader
         eyebrow="Campaigns"
         title="Campaign performance"
         description="Cross-channel campaigns with owners, budget, and conversion signals. Click any row to view the full performance timeline."
-        actions={
-          <button className="rounded-lg bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-white hover:brightness-110">
-            + New campaign
-          </button>
-        }
+        actions={<NewCampaignButton />}
       />
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
@@ -72,7 +67,7 @@ export default function CampaignsPage() {
             {campaigns.map((c) => {
               const cpa = c.conversions ? c.spentCents / c.conversions : 0;
               const progressPct = c.budgetCents ? Math.min(100, Math.round((c.spentCents / c.budgetCents) * 100)) : 0;
-              const count = entryCounts[c.id] ?? 0;
+              const count = c.entryCount;
               return (
                 <tr
                   key={c.id}

--- a/apps/marketing-content/lib/campaigns.ts
+++ b/apps/marketing-content/lib/campaigns.ts
@@ -1,0 +1,150 @@
+import { prisma } from "@asafarim/db";
+import { auth } from "@asafarim/auth";
+
+// ── View types ────────────────────────────────────────────────────────────────
+// These mirror the shapes the campaign UI already consumes (ISO date strings,
+// not Date objects), so the components stay unchanged when swapping the static
+// demo arrays for persisted data.
+
+export type Channel = "seo" | "email" | "paid" | "social" | "partner";
+export type CampaignStatus = "live" | "scheduled" | "paused" | "ended";
+
+export interface CampaignView {
+  id: string;
+  name: string;
+  channel: string;
+  status: string;
+  owner: string;
+  budgetCents: number;
+  spentCents: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  startedAt: string; // YYYY-MM-DD
+  /** true when the signed-in user created this campaign (vs. shared demo data). */
+  isOwn: boolean;
+  /** number of performance entries visible to the current user. */
+  entryCount: number;
+}
+
+export interface PerformanceEntryView {
+  id: string;
+  campaignId: string;
+  weekOf: string; // YYYY-MM-DD
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  spentCents: number;
+  notes?: string;
+  loggedBy: string;
+  loggedAt: string; // ISO timestamp
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Returns the authenticated user's id, or null when unauthenticated.
+ * All campaign routes are behind auth middleware, but reads stay defensive.
+ */
+export async function getCurrentUserId(): Promise<string | null> {
+  const session = await auth();
+  return session?.user?.id ?? null;
+}
+
+/** Campaigns the user may see: shared demo data (ownerId null) + their own. */
+function visibleCampaignWhere(userId: string | null) {
+  return userId
+    ? { OR: [{ ownerId: null }, { ownerId: userId }] }
+    : { ownerId: null };
+}
+
+/** Entries the user may see: shared seed entries + their own logged entries. */
+function visibleEntryWhere(userId: string | null) {
+  return userId
+    ? { OR: [{ loggedById: null }, { loggedById: userId }] }
+    : { loggedById: null };
+}
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+export async function listCampaigns(userId: string | null): Promise<CampaignView[]> {
+  const rows = await prisma.marketingCampaign.findMany({
+    where: visibleCampaignWhere(userId),
+    orderBy: { createdAt: "asc" },
+    include: {
+      _count: { select: { entries: { where: visibleEntryWhere(userId) } } },
+    },
+  });
+
+  return rows.map((c) => ({
+    id: c.id,
+    name: c.name,
+    channel: c.channel,
+    status: c.status,
+    owner: c.owner,
+    budgetCents: c.budgetCents,
+    spentCents: c.spentCents,
+    impressions: c.impressions,
+    clicks: c.clicks,
+    conversions: c.conversions,
+    startedAt: isoDate(c.startedAt),
+    isOwn: c.ownerId != null && c.ownerId === userId,
+    entryCount: c._count.entries,
+  }));
+}
+
+export async function getCampaign(
+  id: string,
+  userId: string | null
+): Promise<CampaignView | null> {
+  const c = await prisma.marketingCampaign.findFirst({
+    where: { id, ...visibleCampaignWhere(userId) },
+    include: {
+      _count: { select: { entries: { where: visibleEntryWhere(userId) } } },
+    },
+  });
+  if (!c) return null;
+
+  return {
+    id: c.id,
+    name: c.name,
+    channel: c.channel,
+    status: c.status,
+    owner: c.owner,
+    budgetCents: c.budgetCents,
+    spentCents: c.spentCents,
+    impressions: c.impressions,
+    clicks: c.clicks,
+    conversions: c.conversions,
+    startedAt: isoDate(c.startedAt),
+    isOwn: c.ownerId != null && c.ownerId === userId,
+    entryCount: c._count.entries,
+  };
+}
+
+export async function listEntries(
+  campaignId: string,
+  userId: string | null
+): Promise<PerformanceEntryView[]> {
+  const rows = await prisma.marketingPerformanceEntry.findMany({
+    where: { campaignId, ...visibleEntryWhere(userId) },
+    orderBy: { weekOf: "asc" },
+  });
+
+  return rows.map((e) => ({
+    id: e.id,
+    campaignId: e.campaignId,
+    weekOf: isoDate(e.weekOf),
+    impressions: e.impressions,
+    clicks: e.clicks,
+    conversions: e.conversions,
+    spentCents: e.spentCents,
+    notes: e.notes ?? undefined,
+    loggedBy: e.loggedBy,
+    loggedAt: e.loggedAt.toISOString(),
+  }));
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
     "db:studio": "dotenv -e ../../.env -- prisma studio",
     "db:seed": "dotenv -e ../../.env -- tsx prisma/seed.ts",
     "db:seed-vionto": "dotenv -e ../../.env -- tsx prisma/seed-vionto-plans.ts",
+    "db:seed-marketing": "dotenv -e ../../.env -- tsx prisma/seed-marketing.ts",
     "seed": "pnpm run db:seed",
     "build": "prisma generate",
     "typecheck": "tsc --noEmit",

--- a/packages/db/prisma/migrations/20260530190000_add_marketing_campaigns/migration.sql
+++ b/packages/db/prisma/migrations/20260530190000_add_marketing_campaigns/migration.sql
@@ -1,0 +1,67 @@
+-- CreateTable
+CREATE TABLE "MarketingCampaign" (
+    "id" TEXT NOT NULL,
+    "ownerId" TEXT,
+    "name" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "owner" TEXT NOT NULL,
+    "budgetCents" INTEGER NOT NULL DEFAULT 0,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "spentCents" INTEGER NOT NULL DEFAULT 0,
+    "impressions" INTEGER NOT NULL DEFAULT 0,
+    "clicks" INTEGER NOT NULL DEFAULT 0,
+    "conversions" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MarketingCampaign_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MarketingPerformanceEntry" (
+    "id" TEXT NOT NULL,
+    "campaignId" TEXT NOT NULL,
+    "weekOf" TIMESTAMP(3) NOT NULL,
+    "impressions" INTEGER NOT NULL DEFAULT 0,
+    "clicks" INTEGER NOT NULL DEFAULT 0,
+    "conversions" INTEGER NOT NULL DEFAULT 0,
+    "spentCents" INTEGER NOT NULL DEFAULT 0,
+    "notes" TEXT,
+    "loggedBy" TEXT NOT NULL,
+    "loggedById" TEXT,
+    "loggedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MarketingPerformanceEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MarketingCampaign_ownerId_idx" ON "MarketingCampaign"("ownerId");
+
+-- CreateIndex
+CREATE INDEX "MarketingCampaign_status_idx" ON "MarketingCampaign"("status");
+
+-- CreateIndex
+CREATE INDEX "MarketingCampaign_channel_idx" ON "MarketingCampaign"("channel");
+
+-- CreateIndex
+CREATE INDEX "MarketingCampaign_startedAt_idx" ON "MarketingCampaign"("startedAt");
+
+-- CreateIndex
+CREATE INDEX "MarketingPerformanceEntry_campaignId_idx" ON "MarketingPerformanceEntry"("campaignId");
+
+-- CreateIndex
+CREATE INDEX "MarketingPerformanceEntry_campaignId_weekOf_idx" ON "MarketingPerformanceEntry"("campaignId", "weekOf");
+
+-- CreateIndex
+CREATE INDEX "MarketingPerformanceEntry_weekOf_idx" ON "MarketingPerformanceEntry"("weekOf");
+
+-- AddForeignKey
+ALTER TABLE "MarketingCampaign" ADD CONSTRAINT "MarketingCampaign_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MarketingPerformanceEntry" ADD CONSTRAINT "MarketingPerformanceEntry_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "MarketingCampaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MarketingPerformanceEntry" ADD CONSTRAINT "MarketingPerformanceEntry_loggedById_fkey" FOREIGN KEY ("loggedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -87,6 +87,10 @@ model User {
   // Generic user locations (home, work, etc.) - reusable across all apps
   locations UserLocation[]
 
+  // Marketing + Content engine
+  marketingCampaigns        MarketingCampaign[]
+  marketingPerformanceLogged MarketingPerformanceEntry[] @relation("MarketingEntryLoggedBy")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1778,4 +1782,71 @@ model ViontoAlbumItem {
   @@unique([albumId, assetId])
   @@index([albumId, orderIndex])
   @@index([assetId])
+}
+
+// ─── Marketing + Content Engine ───────────────────────────────
+//
+// Cross-channel marketing campaigns and their weekly performance logs.
+// Records with ownerId = null are the shared showcase/demo dataset visible
+// to every authenticated user. Records created by a user carry their ownerId
+// and are private to that user. Campaign-level totals (spent/impressions/
+// clicks/conversions) are denormalized roll-ups kept in sync from the entries
+// on every write so the list and detail views report identical numbers.
+
+model MarketingCampaign {
+  id      String  @id @default(cuid())
+  /// null = shared demo data; otherwise scoped to the creating user.
+  ownerId String?
+
+  name      String
+  channel   String // seo, email, paid, social, partner
+  status    String @default("scheduled") // live, scheduled, paused, ended
+  owner     String // display name of the campaign owner
+  budgetCents Int  @default(0)
+  startedAt DateTime
+
+  // Denormalized roll-ups, recomputed from entries on write.
+  spentCents  Int @default(0)
+  impressions Int @default(0)
+  clicks      Int @default(0)
+  conversions Int @default(0)
+
+  entries   MarketingPerformanceEntry[]
+  ownerUser User?                       @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([ownerId])
+  @@index([status])
+  @@index([channel])
+  @@index([startedAt])
+}
+
+model MarketingPerformanceEntry {
+  id         String   @id @default(cuid())
+  campaignId String
+  /// ISO date of the Monday that starts this reporting week.
+  weekOf     DateTime
+
+  impressions Int     @default(0)
+  clicks      Int     @default(0)
+  conversions Int     @default(0)
+  spentCents  Int     @default(0)
+  notes       String? @db.Text
+
+  /// Display name of who logged the entry.
+  loggedBy   String
+  /// User who logged the entry (null for seed data). Audit detail in M3.
+  loggedById String?
+  loggedAt   DateTime @default(now())
+
+  campaign       MarketingCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  loggedByUser   User?             @relation("MarketingEntryLoggedBy", fields: [loggedById], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+
+  @@index([campaignId])
+  @@index([campaignId, weekOf])
+  @@index([weekOf])
 }

--- a/packages/db/prisma/seed-marketing.ts
+++ b/packages/db/prisma/seed-marketing.ts
@@ -1,0 +1,157 @@
+/**
+ * Seed the Marketing + Content engine showcase dataset.
+ *
+ * These records form the shared demo surface for the marketing-content app:
+ * every campaign and performance entry is created with ownerId / loggedById
+ * = null, which the app treats as "shared demo data visible to all users".
+ * User-created campaigns and entries carry their own owner and stay private.
+ *
+ * Idempotent: keyed by the stable demo ids (c1.., pe-c1-w1..), so re-running
+ * updates in place instead of duplicating.
+ *
+ * Run with: pnpm --filter @asafarim/db db:seed-marketing
+ */
+
+import { prisma } from "../src/index";
+
+type CampaignSeed = {
+  id: string;
+  name: string;
+  channel: string;
+  status: string;
+  owner: string;
+  budgetCents: number;
+  spentCents: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  startedAt: string;
+};
+
+type EntrySeed = {
+  id: string;
+  campaignId: string;
+  weekOf: string;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  spentCents: number;
+  notes?: string;
+  loggedBy: string;
+  loggedAt: string;
+};
+
+const campaigns: CampaignSeed[] = [
+  { id: "c1", name: "Q2 Growth — Ops Hub launch", channel: "paid", status: "live", owner: "Ava Chen", budgetCents: 1_200_000, spentCents: 812_400, impressions: 412_800, clicks: 18_420, conversions: 612, startedAt: "2026-03-18" },
+  { id: "c2", name: "SEO cluster: agent workflows", channel: "seo", status: "live", owner: "Noah Park", budgetCents: 400_000, spentCents: 220_000, impressions: 268_100, clicks: 9_850, conversions: 441, startedAt: "2026-02-04" },
+  { id: "c3", name: "Lifecycle nurture v4", channel: "email", status: "live", owner: "Priya Raman", budgetCents: 180_000, spentCents: 96_300, impressions: 54_200, clicks: 7_140, conversions: 389, startedAt: "2026-03-01" },
+  { id: "c4", name: "LinkedIn founder series", channel: "social", status: "live", owner: "Marcus King", budgetCents: 250_000, spentCents: 134_900, impressions: 186_500, clicks: 6_220, conversions: 141, startedAt: "2026-03-10" },
+  { id: "c5", name: "Partner co-marketing — Stripe", channel: "partner", status: "scheduled", owner: "Ava Chen", budgetCents: 500_000, spentCents: 0, impressions: 0, clicks: 0, conversions: 0, startedAt: "2026-05-02" },
+  { id: "c6", name: "Retargeting — pricing page", channel: "paid", status: "live", owner: "Noah Park", budgetCents: 300_000, spentCents: 241_100, impressions: 142_700, clicks: 4_980, conversions: 198, startedAt: "2026-02-20" },
+  { id: "c7", name: "Webinar: Measuring AI ROI", channel: "email", status: "ended", owner: "Priya Raman", budgetCents: 120_000, spentCents: 118_700, impressions: 38_900, clicks: 5_110, conversions: 262, startedAt: "2026-01-14" },
+  { id: "c8", name: "Community push: r/devtools", channel: "social", status: "paused", owner: "Marcus King", budgetCents: 80_000, spentCents: 44_200, impressions: 72_300, clicks: 2_140, conversions: 48, startedAt: "2026-02-28" },
+];
+
+const performanceEntries: EntrySeed[] = [
+  // c1
+  { id: "pe-c1-w1", campaignId: "c1", weekOf: "2026-03-18", impressions: 38_200, clicks: 1_620, conversions: 47, spentCents: 98_000, notes: "Launch week — awareness phase, CPM higher than expected.", loggedBy: "Ava Chen", loggedAt: "2026-03-25T10:02:00Z" },
+  { id: "pe-c1-w2", campaignId: "c1", weekOf: "2026-03-25", impressions: 54_100, clicks: 2_340, conversions: 71, spentCents: 128_000, notes: "Bid strategy adjusted; CTR improved after headline A/B test.", loggedBy: "Ava Chen", loggedAt: "2026-04-01T09:14:00Z" },
+  { id: "pe-c1-w3", campaignId: "c1", weekOf: "2026-04-01", impressions: 61_400, clicks: 2_870, conversions: 96, spentCents: 141_000, notes: "Best week so far — retargeting layer activated.", loggedBy: "Noah Park", loggedAt: "2026-04-08T11:30:00Z" },
+  { id: "pe-c1-w4", campaignId: "c1", weekOf: "2026-04-08", impressions: 72_600, clicks: 3_240, conversions: 118, spentCents: 162_000, notes: "Blog post amplification drove incremental conversions.", loggedBy: "Ava Chen", loggedAt: "2026-04-15T08:45:00Z" },
+  { id: "pe-c1-w5", campaignId: "c1", weekOf: "2026-04-15", impressions: 78_300, clicks: 3_510, conversions: 134, spentCents: 170_000, notes: "Peak reach — frequency cap lowered to preserve brand sentiment.", loggedBy: "Noah Park", loggedAt: "2026-04-22T10:00:00Z" },
+  { id: "pe-c1-w6", campaignId: "c1", weekOf: "2026-04-22", impressions: 63_100, clicks: 2_780, conversions: 98, spentCents: 150_000, notes: "Slight dip; competitor launched counter-campaign.", loggedBy: "Ava Chen", loggedAt: "2026-04-29T09:25:00Z" },
+  { id: "pe-c1-w7", campaignId: "c1", weekOf: "2026-04-29", impressions: 45_100, clicks: 2_060, conversions: 48, spentCents: 98_000, notes: "Budget pacing to month-end. CPA remains within $140 target.", loggedBy: "Ava Chen", loggedAt: "2026-05-06T09:10:00Z" },
+  // c2
+  { id: "pe-c2-w1", campaignId: "c2", weekOf: "2026-02-04", impressions: 14_200, clicks: 520, conversions: 22, spentCents: 14_000, notes: "Initial content sprint; 4 new guides published.", loggedBy: "Noah Park", loggedAt: "2026-02-11T12:00:00Z" },
+  { id: "pe-c2-w2", campaignId: "c2", weekOf: "2026-02-11", impressions: 18_400, clicks: 680, conversions: 31, spentCents: 18_000, notes: "Internal link pass done — impressions +30% WoW.", loggedBy: "Noah Park", loggedAt: "2026-02-18T11:30:00Z" },
+  { id: "pe-c2-w3", campaignId: "c2", weekOf: "2026-02-18", impressions: 21_900, clicks: 810, conversions: 38, spentCents: 20_000, notes: "Featured snippet captured for 'ai agent workflow tools'.", loggedBy: "Noah Park", loggedAt: "2026-02-25T10:45:00Z" },
+  { id: "pe-c2-w4", campaignId: "c2", weekOf: "2026-02-25", impressions: 24_600, clicks: 950, conversions: 44, spentCents: 22_000, notes: "Added schema markup — click-through rate up 8%.", loggedBy: "Ava Chen", loggedAt: "2026-03-04T09:00:00Z" },
+  { id: "pe-c2-w5", campaignId: "c2", weekOf: "2026-03-04", impressions: 27_100, clicks: 1_080, conversions: 50, spentCents: 24_000, notes: "Video embed added to top guide — dwell time up.", loggedBy: "Noah Park", loggedAt: "2026-03-11T11:15:00Z" },
+  { id: "pe-c2-w6", campaignId: "c2", weekOf: "2026-03-11", impressions: 29_800, clicks: 1_190, conversions: 57, spentCents: 26_000, notes: "Average position improved 4.8 to 3.9 for top 5 keywords.", loggedBy: "Noah Park", loggedAt: "2026-03-18T10:30:00Z" },
+  { id: "pe-c2-w7", campaignId: "c2", weekOf: "2026-03-18", impressions: 32_400, clicks: 1_320, conversions: 62, spentCents: 28_000, notes: "Seasonal spike in 'agent workflow' searches.", loggedBy: "Ava Chen", loggedAt: "2026-03-25T09:45:00Z" },
+  { id: "pe-c2-w8", campaignId: "c2", weekOf: "2026-03-25", impressions: 33_700, clicks: 1_400, conversions: 68, spentCents: 28_000, notes: "Blog amplification from paid campaign (c1) cross-traffic.", loggedBy: "Noah Park", loggedAt: "2026-04-01T10:00:00Z" },
+  { id: "pe-c2-w9", campaignId: "c2", weekOf: "2026-04-01", impressions: 34_500, clicks: 1_430, conversions: 69, spentCents: 28_000, notes: "Stable week; monitoring for algorithm update.", loggedBy: "Noah Park", loggedAt: "2026-04-08T11:00:00Z" },
+  // c3
+  { id: "pe-c3-w1", campaignId: "c3", weekOf: "2026-03-01", impressions: 4_800, clicks: 620, conversions: 32, spentCents: 9_000, notes: "Email 1 deployed — open rate 41%, best in history.", loggedBy: "Priya Raman", loggedAt: "2026-03-08T09:30:00Z" },
+  { id: "pe-c3-w2", campaignId: "c3", weekOf: "2026-03-08", impressions: 6_100, clicks: 810, conversions: 46, spentCents: 11_000, notes: "Email 2 (day 3) boosted by personalised subject line test.", loggedBy: "Priya Raman", loggedAt: "2026-03-15T10:00:00Z" },
+  { id: "pe-c3-w3", campaignId: "c3", weekOf: "2026-03-15", impressions: 7_400, clicks: 980, conversions: 58, spentCents: 13_000, notes: "Activation push landed 58 trials — pipeline impact visible.", loggedBy: "Priya Raman", loggedAt: "2026-03-22T11:15:00Z" },
+  { id: "pe-c3-w4", campaignId: "c3", weekOf: "2026-03-22", impressions: 8_200, clicks: 1_080, conversions: 64, spentCents: 14_000, notes: "Segmented high-score leads to SDR hand-off flow.", loggedBy: "Priya Raman", loggedAt: "2026-03-29T09:45:00Z" },
+  { id: "pe-c3-w5", campaignId: "c3", weekOf: "2026-03-29", impressions: 9_600, clicks: 1_240, conversions: 72, spentCents: 16_000, notes: "Week 5 drip fired — churn_risk cohort added.", loggedBy: "Priya Raman", loggedAt: "2026-04-05T10:30:00Z" },
+  { id: "pe-c3-w6", campaignId: "c3", weekOf: "2026-04-05", impressions: 9_800, clicks: 1_190, conversions: 68, spentCents: 16_000, notes: "Slight drop — Easter weekend suppressed opens Fri-Sun.", loggedBy: "Priya Raman", loggedAt: "2026-04-12T09:00:00Z" },
+  { id: "pe-c3-w7", campaignId: "c3", weekOf: "2026-04-12", impressions: 8_300, clicks: 1_220, conversions: 49, spentCents: 17_300, notes: "New cohort (week 7 re-engagement) just kicked off.", loggedBy: "Priya Raman", loggedAt: "2026-04-19T10:15:00Z" },
+  // c4
+  { id: "pe-c4-w1", campaignId: "c4", weekOf: "2026-03-10", impressions: 18_600, clicks: 580, conversions: 12, spentCents: 14_000, notes: "Episode 1 posted — organic amplification exceeded target.", loggedBy: "Marcus King", loggedAt: "2026-03-17T10:00:00Z" },
+  { id: "pe-c4-w2", campaignId: "c4", weekOf: "2026-03-17", impressions: 24_400, clicks: 780, conversions: 19, spentCents: 18_000, notes: "Episode 2 (pricing tension) — highest engagement so far.", loggedBy: "Marcus King", loggedAt: "2026-03-24T09:30:00Z" },
+  { id: "pe-c4-w3", campaignId: "c4", weekOf: "2026-03-24", impressions: 27_100, clicks: 870, conversions: 24, spentCents: 21_000, notes: "Comment velocity high — boosted episode 3 with $3k.", loggedBy: "Marcus King", loggedAt: "2026-03-31T11:00:00Z" },
+  { id: "pe-c4-w4", campaignId: "c4", weekOf: "2026-03-31", impressions: 31_200, clicks: 1_010, conversions: 29, spentCents: 24_000, notes: "Audience targeting refined — follower lookalike added.", loggedBy: "Marcus King", loggedAt: "2026-04-07T10:30:00Z" },
+  { id: "pe-c4-w5", campaignId: "c4", weekOf: "2026-04-07", impressions: 34_800, clicks: 1_120, conversions: 31, spentCents: 26_000, notes: "Best reach week — thought-leader re-share drove spikes.", loggedBy: "Marcus King", loggedAt: "2026-04-14T09:45:00Z" },
+  { id: "pe-c4-w6", campaignId: "c4", weekOf: "2026-04-14", impressions: 30_400, clicks: 960, conversions: 18, spentCents: 22_000, notes: "Engagement normalising; refresh creative for ep 7.", loggedBy: "Marcus King", loggedAt: "2026-04-21T10:15:00Z" },
+  { id: "pe-c4-w7", campaignId: "c4", weekOf: "2026-04-21", impressions: 20_000, clicks: 900, conversions: 8, spentCents: 9_900, notes: "Pacing to budget ceiling; held spend for May push.", loggedBy: "Marcus King", loggedAt: "2026-04-28T11:00:00Z" },
+  // c7
+  { id: "pe-c7-w1", campaignId: "c7", weekOf: "2026-01-14", impressions: 8_200, clicks: 1_040, conversions: 52, spentCents: 24_000, notes: "Invitation blast sent; 52 registrations day 1.", loggedBy: "Priya Raman", loggedAt: "2026-01-21T10:00:00Z" },
+  { id: "pe-c7-w2", campaignId: "c7", weekOf: "2026-01-21", impressions: 9_800, clicks: 1_320, conversions: 76, spentCents: 29_000, notes: "Reminder sequence boosted attendance intent.", loggedBy: "Priya Raman", loggedAt: "2026-01-28T09:30:00Z" },
+  { id: "pe-c7-w3", campaignId: "c7", weekOf: "2026-01-28", impressions: 11_400, clicks: 1_600, conversions: 88, spentCents: 34_000, notes: "Webinar week — live attendees 310 (target: 250).", loggedBy: "Priya Raman", loggedAt: "2026-02-04T10:15:00Z" },
+  { id: "pe-c7-w4", campaignId: "c7", weekOf: "2026-02-04", impressions: 9_500, clicks: 1_150, conversions: 46, spentCents: 31_700, notes: "On-demand replay sent; replay CVR 14% above estimate.", loggedBy: "Priya Raman", loggedAt: "2026-02-11T11:00:00Z" },
+];
+
+async function main() {
+  console.log("🌱 Seeding Marketing + Content showcase dataset...");
+
+  // Seed in order so createdAt increments c1..c8 (preserves list order).
+  let order = 0;
+  for (const c of campaigns) {
+    const base = {
+      ownerId: null,
+      name: c.name,
+      channel: c.channel,
+      status: c.status,
+      owner: c.owner,
+      budgetCents: c.budgetCents,
+      spentCents: c.spentCents,
+      impressions: c.impressions,
+      clicks: c.clicks,
+      conversions: c.conversions,
+      startedAt: new Date(`${c.startedAt}T00:00:00Z`),
+      createdAt: new Date(Date.UTC(2026, 0, 1) + order * 60_000),
+    };
+    await prisma.marketingCampaign.upsert({
+      where: { id: c.id },
+      update: base,
+      create: { id: c.id, ...base },
+    });
+    order += 1;
+    console.log(`  ✓ Campaign: ${c.id} — ${c.name}`);
+  }
+
+  for (const e of performanceEntries) {
+    const base = {
+      campaignId: e.campaignId,
+      weekOf: new Date(`${e.weekOf}T00:00:00Z`),
+      impressions: e.impressions,
+      clicks: e.clicks,
+      conversions: e.conversions,
+      spentCents: e.spentCents,
+      notes: e.notes ?? null,
+      loggedBy: e.loggedBy,
+      loggedById: null,
+      loggedAt: new Date(e.loggedAt),
+    };
+    await prisma.marketingPerformanceEntry.upsert({
+      where: { id: e.id },
+      update: base,
+      create: { id: e.id, ...base },
+    });
+  }
+  console.log(`  ✓ Performance entries: ${performanceEntries.length}`);
+
+  console.log("✅ Marketing showcase dataset seeded successfully!");
+}
+
+main()
+  .catch((e) => {
+    console.error("❌ Seed failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -60,4 +60,6 @@ export type {
   ViontoRenderJob,
   ViontoExport,
   ViontoAuditEvent,
+  MarketingCampaign,
+  MarketingPerformanceEntry,
 } from "@prisma/client";


### PR DESCRIPTION
- Add MarketingCampaign and MarketingPerformanceEntry models to Prisma schema with ownerId scoping (null = shared demo data)
- Campaign denormalized totals (spent/impressions/clicks/conversions) synced from entries
- Add db:seed-marketing script and launch.json config for marketing-content app
- Implement getCampaign, listCampaigns, listEntries, and logPerformanceEntry server actions
- Replace demo-data imports with database queries

Refs #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create and manage marketing campaigns across multiple channels (SEO, email, paid, social, partner) with budget tracking.
  * Log weekly performance metrics including impressions, clicks, conversions, and spend to monitor campaign ROI.
  * View campaign dashboards with real-time performance data, totals, and entry counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AliSafari-IT/asafarim-digital/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->