### PR TITLE
feat(vionto): Google Photos import foundation (#144, #145, #146)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ AUTH_GOOGLE_ID=***
 AUTH_GOOGLE_SECRET=***
 AUTH_GOOGLE_CALLBACK_URL=https://portal.asafarim.com/api/auth/callback/google
 
+# Vionto — Google Photos import (separate incremental-OAuth grant, Photos scopes).
+# See apps/vionto/.env.example and apps/vionto/docs/google-photos-import.md.
+GOOGLE_PHOTOS_CLIENT_ID=
+GOOGLE_PHOTOS_CLIENT_SECRET=
+GOOGLE_PHOTOS_REDIRECT_URI=https://vionto.asafarim.com/api/integrations/google-photos/callback
+GOOGLE_PHOTOS_SCOPES=https://www.googleapis.com/auth/photospicker.mediaitems.readonly
+# 32-byte AES-256-GCM key for encrypting stored OAuth tokens (openssl rand -hex 32).
+VIONTO_TOKEN_ENCRYPTION_KEY=
+
 # â”€â”€â”€ App URLs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 PORTAL_URL=https://portal.asafarim.com
 # Client-visible portal URL used by cross-app navigation buttons.

--- a/apps/vionto/.env.example
+++ b/apps/vionto/.env.example
@@ -25,3 +25,20 @@ DO_SPACES_PUBLIC_URL=
 OPENAI_API_KEY=
 ELEVENLABS_API_KEY=
 WORKER_HEALTH_PORT=3007
+
+# ─── Google Photos Import ───────────────────────────────────────
+# OAuth client for importing photos from a user's Google Photos library and
+# shared albums. This is a SEPARATE, incremental authorization from login —
+# the consent screen needs the Photos Picker / Library API scopes enabled.
+# Create the client + enable APIs in Google Cloud Console:
+#   https://console.cloud.google.com/apis/credentials
+# You may reuse the portal's AUTH_GOOGLE_* client only if its consent screen
+# has the Photos scopes added; otherwise use a dedicated client below.
+GOOGLE_PHOTOS_CLIENT_ID=
+GOOGLE_PHOTOS_CLIENT_SECRET=
+GOOGLE_PHOTOS_REDIRECT_URI=http://localhost:3006/api/integrations/google-photos/callback
+# Space- or comma-separated OAuth scopes (see docs/google-photos-import.md).
+GOOGLE_PHOTOS_SCOPES=https://www.googleapis.com/auth/photospicker.mediaitems.readonly
+# 32-byte key used to encrypt stored OAuth tokens at rest (AES-256-GCM).
+# Generate with: openssl rand -hex 32
+VIONTO_TOKEN_ENCRYPTION_KEY=

--- a/apps/vionto/README.md
+++ b/apps/vionto/README.md
@@ -54,6 +54,13 @@ AUTH_COOKIE_DOMAIN=.asafarim.com
 
 # Database (shared)
 DATABASE_URL=postgresql://...
+
+# Google Photos import (see docs/google-photos-import.md)
+GOOGLE_PHOTOS_CLIENT_ID=...
+GOOGLE_PHOTOS_CLIENT_SECRET=...
+GOOGLE_PHOTOS_REDIRECT_URI=https://vionto.asafarim.com/api/integrations/google-photos/callback
+GOOGLE_PHOTOS_SCOPES=https://www.googleapis.com/auth/photospicker.mediaitems.readonly
+VIONTO_TOKEN_ENCRYPTION_KEY=...  # openssl rand -hex 32 (encrypts stored OAuth tokens)
 ```
 
 ## Current Scope

--- a/apps/vionto/docs/google-photos-import.md
+++ b/apps/vionto/docs/google-photos-import.md
@@ -1,0 +1,205 @@
+# Google Photos Import — Design & Decision Record
+
+> Milestone: **Vionto: Google Photos Import** ([#2](https://github.com/AliSafari-IT/asafarim-digital/milestone/2))
+> Status: **Foundation landed** (spike decision, env/config, data model). Backend & UI tracked in follow-up issues.
+> Last updated: 2026-05-31
+
+This is the output of the spike ([#144](https://github.com/AliSafari-IT/asafarim-digital/issues/144))
+plus the configuration ([#145](https://github.com/AliSafari-IT/asafarim-digital/issues/145))
+and data-model ([#146](https://github.com/AliSafari-IT/asafarim-digital/issues/146)) decisions.
+
+---
+
+## 1. Goal
+
+Let a signed-in Vionto user import photos into the current upload session from:
+
+1. **Their own Google Photos library** — user-selected photos.
+2. **A shared Google Photos album link** — paste a URL, import its media.
+
+If the user is not yet authorized for Google Photos, they can **grant Vionto
+access** (an OAuth consent flow) and then import — regardless of how they
+logged into Vionto (Google, email/password, or email-code).
+
+---
+
+## 2. Key constraint: the Library API was restricted
+
+Google **restricted the Photos Library API** effective **2025-03-31**. The broad
+`photoslibrary.readonly` scope (read a user's entire library) is no longer
+granted to general apps — it now only exposes **app-created** media. This breaks
+the "list the whole library and let the user pick" approach that older guides
+describe.
+
+The supported replacement for **user-initiated import of arbitrary photos** is
+the **Google Photos Picker API**: the app creates a *picker session*, sends the
+user to Google's own picker UI, the user selects items there, and the app then
+reads **only the selected** `mediaItems`. The user never grants blanket library
+access — they hand-pick exactly what to share, session by session.
+
+### Decision
+
+| Use case | Chosen approach |
+| --- | --- |
+| Import from own library | **Photos Picker API** (`photospicker.mediaitems.readonly`) |
+| Import from a shared album link | **Picker-first**, with Library-API sharing as a *gated* stretch (see §4) |
+
+Rationale: the Picker API is the only path Google fully supports for general
+apps post-restriction, it requires a **non-sensitive** scope (lighter
+verification), and it gives users per-import consent — a privacy win.
+
+---
+
+## 3. OAuth scopes
+
+| Scope | Purpose | Sensitivity |
+| --- | --- | --- |
+| `https://www.googleapis.com/auth/photospicker.mediaitems.readonly` | Read the items a user picked in a Picker session | Non-sensitive |
+
+Configured via `GOOGLE_PHOTOS_SCOPES` (space/comma-separated). Additional scopes
+will be appended here if/when the shared-album path (§4) needs them.
+
+**Verification:** the Picker scope is not on Google's "sensitive/restricted"
+list, so first-launch verification is light. If we later add a restricted
+sharing scope, that triggers Google's restricted-scope verification + security
+assessment — **start that early** because it can take weeks.
+
+---
+
+## 4. Shared album links — feasibility
+
+Importing directly from a shared album **URL** historically used the Library API
+sharing surface (`sharedAlbums`, join via `shareToken`, then
+`mediaItems.search`). Those endpoints fall under the **restricted** Library API
+scopes that now require Google verification + a security assessment, and only
+return app-created data for general apps.
+
+### Decision: ship the Picker path first; treat URL-based shared-album import as gated
+
+- **Phase 1 (default):** When a user pastes a shared-album link, route them
+  through the **Picker** (they open the album in Google and select from it).
+  This needs no extra scope and works today.
+- **Phase 2 (stretch, gated):** True URL → enumerate-items import, *only if* we
+  obtain the restricted sharing scope and pass Google's assessment. Issues
+  [#150](https://github.com/AliSafari-IT/asafarim-digital/issues/150) and
+  [#154](https://github.com/AliSafari-IT/asafarim-digital/issues/154) carry this
+  caveat and will be re-scoped to the Picker fallback if approval is not
+  obtained.
+
+---
+
+## 5. Token strategy: incremental OAuth, decoupled from login
+
+Vionto login already supports Google, email/password, and email-code
+(`@asafarim/auth`). Photo import authorization is modelled as a **separate,
+incremental OAuth grant** rather than piggybacking on the login identity:
+
+- A user who logged in with **email/password or email-code** can still connect a
+  Google account purely for importing photos.
+- A user who logged in **with Google** is asked only for the *additional* Photos
+  scope (incremental authorization) on top of their existing session.
+
+We use a **dedicated OAuth client** (`GOOGLE_PHOTOS_CLIENT_ID/SECRET`) with its
+own redirect URI (`/api/integrations/google-photos/callback`). It may reuse the
+portal's `AUTH_GOOGLE_*` client **only** if that client's consent screen has the
+Photos scopes added; a dedicated client keeps concerns separate and is preferred.
+
+The grant is requested with `access_type=offline` + `prompt=consent` so we
+reliably receive a **refresh token** for long-lived, background-free re-imports.
+
+---
+
+## 6. Data model (landed)
+
+`GooglePhotosConnection` (Prisma, `@asafarim/db`) — one row per user:
+
+| Column | Notes |
+| --- | --- |
+| `userId` (unique, FK→User, cascade delete) | Connection is per Vionto user |
+| `googleAccountEmail`, `googleAccountSub` | The Google account that granted access (may differ from login email) |
+| `accessTokenEnc`, `refreshTokenEnc` | OAuth tokens, **encrypted at rest** (never plaintext) |
+| `scopes` (`String[]`) | Granted scopes |
+| `expiresAt` | Access-token expiry |
+| `status` (`active`\|`revoked`\|`error`) + `lastError` | Lifecycle |
+| `lastRefreshAt`, `lastImportedAt` | Diagnostics |
+
+Migration: `packages/db/prisma/migrations/20260531120000_add_google_photos_connection`.
+
+### Token encryption
+
+Tokens are encrypted with **AES-256-GCM** (authenticated; tampering is detected
+on decrypt) using `VIONTO_TOKEN_ENCRYPTION_KEY` (a 32-byte key — 64 hex chars or
+base64). Payload format: `iv.authTag.ciphertext` (base64url).
+
+- Crypto helpers: [`lib/server/google-photos/crypto.ts`](../lib/server/google-photos/crypto.ts)
+- Repository (encrypt/decrypt + upsert/refresh/delete): [`lib/server/google-photos/connection.ts`](../lib/server/google-photos/connection.ts)
+- Tests: `lib/server/__tests__/google-photos-crypto.test.ts`, `…-connection.test.ts`
+
+The repository is the **only** layer that touches the encrypted columns; routes
+and the import pipeline consume the decrypted `GooglePhotosConnectionView`.
+
+---
+
+## 7. Configuration
+
+| Env var | Purpose |
+| --- | --- |
+| `GOOGLE_PHOTOS_CLIENT_ID` / `GOOGLE_PHOTOS_CLIENT_SECRET` | OAuth client for the Photos grant |
+| `GOOGLE_PHOTOS_REDIRECT_URI` | OAuth callback (`…/api/integrations/google-photos/callback`) |
+| `GOOGLE_PHOTOS_SCOPES` | Space/comma-separated scopes (default: Picker readonly) |
+| `VIONTO_TOKEN_ENCRYPTION_KEY` | 32-byte AES-256-GCM key (`openssl rand -hex 32`) |
+
+See [`apps/vionto/.env.example`](../.env.example) and the root `.env.example`.
+
+### Google Cloud Console setup (manual, [#145](https://github.com/AliSafari-IT/asafarim-digital/issues/145))
+
+1. Enable the **Photos Picker API** (and Photos Library API only if Phase 2 is pursued).
+2. Configure the **OAuth consent screen**: add the Picker scope, app domain,
+   privacy-policy + terms URLs, and per-scope justifications.
+3. Create an **OAuth client** (Web), add redirect URIs for local
+   (`http://localhost:3006/...`) and prod (`https://vionto.asafarim.com/...`).
+4. Copy the client id/secret into the deployment secrets.
+5. If a restricted scope is added later, **begin Google verification early**.
+
+---
+
+## 8. End-to-end flow (target)
+
+```
+User (any login)
+  └─ "Connect Google Photos"  ──▶  /api/integrations/google-photos/connect
+        consent (offline, prompt=consent)
+        └─ /callback ──▶ exchange code ──▶ upsert GooglePhotosConnection (tokens encrypted)
+
+Import (library)
+  └─ create Picker session ──▶ user picks in Google UI ──▶ poll until done
+        └─ list selected mediaItems ──▶ /import ──▶ download baseUrl
+              └─ stream to Spaces/S3 (user-scoped key) ──▶ stage in upload session
+                    └─ appears in ImageOrganizer, same as a normal upload
+```
+
+Token freshness is handled by a `getValidGooglePhotosAccessToken(userId)` helper
+(issue [#148](https://github.com/AliSafari-IT/asafarim-digital/issues/148)) that
+refreshes via the stored refresh token and persists the new token through
+`updateGooglePhotosAccessToken`.
+
+---
+
+## 9. Privacy & compliance (issue [#156](https://github.com/AliSafari-IT/asafarim-digital/issues/156))
+
+- Disclose Google Photos access and **Limited Use** in `/privacy` and `/terms`.
+- Show an in-product consent/explanation before the first connect.
+- On **disconnect** and on **account deletion**, revoke tokens at Google and
+  delete the `GooglePhotosConnection` row (wired into retention enforcement).
+
+---
+
+## 10. Open items handed to follow-up issues
+
+- OAuth connect/callback routes + incremental authorization — [#147](https://github.com/AliSafari-IT/asafarim-digital/issues/147)
+- Token refresh, status, disconnect/revoke — [#148](https://github.com/AliSafari-IT/asafarim-digital/issues/148)
+- Picker session API — [#149](https://github.com/AliSafari-IT/asafarim-digital/issues/149)
+- Shared-album import (gated) — [#150](https://github.com/AliSafari-IT/asafarim-digital/issues/150)
+- Download/ingest pipeline — [#151](https://github.com/AliSafari-IT/asafarim-digital/issues/151)
+- Frontend connect/import UI — [#152](https://github.com/AliSafari-IT/asafarim-digital/issues/152), [#153](https://github.com/AliSafari-IT/asafarim-digital/issues/153), [#154](https://github.com/AliSafari-IT/asafarim-digital/issues/154)
+- Quotas/retries, compliance, tests/docs — [#155](https://github.com/AliSafari-IT/asafarim-digital/issues/155), [#156](https://github.com/AliSafari-IT/asafarim-digital/issues/156), [#157](https://github.com/AliSafari-IT/asafarim-digital/issues/157)

--- a/apps/vionto/lib/server/__tests__/google-photos-connection.test.ts
+++ b/apps/vionto/lib/server/__tests__/google-photos-connection.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` is hoisted above top-level declarations, so the store and mock
+// must be created inside `vi.hoisted` to be referenceable from the factory.
+const { store, googlePhotosConnection } = vi.hoisted(() => {
+  // In-memory stand-in for the single-row-per-user connection table.
+  const store = new Map<string, Record<string, unknown>>();
+
+  const googlePhotosConnection = {
+    findUnique: vi.fn(
+      async ({ where: { userId } }: { where: { userId: string } }) =>
+        store.get(userId) ?? null,
+    ),
+    upsert: vi.fn(
+      async ({
+        where: { userId },
+        create,
+        update,
+      }: {
+        where: { userId: string };
+        create: Record<string, unknown>;
+        update: Record<string, unknown>;
+      }) => {
+        const existing = store.get(userId);
+        const now = new Date();
+        const row = existing
+          ? { ...existing, ...update, updatedAt: now }
+          : {
+              id: `cuid_${userId}`,
+              createdAt: now,
+              updatedAt: now,
+              googleAccountEmail: null,
+              googleAccountSub: null,
+              refreshTokenEnc: null,
+              expiresAt: null,
+              lastError: null,
+              lastRefreshAt: null,
+              lastImportedAt: null,
+              ...create,
+            };
+        store.set(userId, row);
+        return row;
+      },
+    ),
+    update: vi.fn(
+      async ({
+        where: { userId },
+        data,
+      }: {
+        where: { userId: string };
+        data: Record<string, unknown>;
+      }) => {
+        const existing = store.get(userId);
+        if (!existing) throw new Error("Record not found");
+        const row = { ...existing, ...data, updatedAt: new Date() };
+        store.set(userId, row);
+        return row;
+      },
+    ),
+    deleteMany: vi.fn(
+      async ({ where: { userId } }: { where: { userId: string } }) => {
+        const had = store.has(userId);
+        store.delete(userId);
+        return { count: had ? 1 : 0 };
+      },
+    ),
+  };
+
+  return { store, googlePhotosConnection };
+});
+
+vi.mock("@asafarim/db", () => ({
+  prisma: { googlePhotosConnection },
+}));
+
+// Import after the mock is registered.
+import {
+  deleteGooglePhotosConnection,
+  getGooglePhotosConnection,
+  markGooglePhotosConnectionError,
+  updateGooglePhotosAccessToken,
+  upsertGooglePhotosConnection,
+} from "../google-photos/connection";
+import { __resetEncryptionKeyCache } from "../google-photos/crypto";
+
+describe("google-photos connection repository", () => {
+  const originalKey = process.env.VIONTO_TOKEN_ENCRYPTION_KEY;
+  const userId = "user_123";
+
+  beforeEach(() => {
+    process.env.VIONTO_TOKEN_ENCRYPTION_KEY = "0".repeat(64);
+    __resetEncryptionKeyCache();
+    store.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.VIONTO_TOKEN_ENCRYPTION_KEY = originalKey;
+    __resetEncryptionKeyCache();
+  });
+
+  it("returns null when no connection exists", async () => {
+    expect(await getGooglePhotosConnection(userId)).toBeNull();
+  });
+
+  it("encrypts tokens at rest and decrypts them on read", async () => {
+    await upsertGooglePhotosConnection({
+      userId,
+      accessToken: "access-abc",
+      refreshToken: "refresh-xyz",
+      scopes: ["https://www.googleapis.com/auth/photospicker.mediaitems.readonly"],
+      googleAccountEmail: "photos@gmail.com",
+      googleAccountSub: "sub-1",
+      expiresAt: new Date("2030-01-01T00:00:00Z"),
+    });
+
+    // Raw stored row must not contain plaintext tokens.
+    const raw = store.get(userId)!;
+    expect(raw.accessTokenEnc).not.toBe("access-abc");
+    expect(String(raw.accessTokenEnc)).not.toContain("access-abc");
+    expect(String(raw.refreshTokenEnc)).not.toContain("refresh-xyz");
+
+    const view = await getGooglePhotosConnection(userId);
+    expect(view).not.toBeNull();
+    expect(view!.accessToken).toBe("access-abc");
+    expect(view!.refreshToken).toBe("refresh-xyz");
+    expect(view!.googleAccountEmail).toBe("photos@gmail.com");
+    expect(view!.scopes).toHaveLength(1);
+    expect(view!.status).toBe("active");
+  });
+
+  it("preserves the existing refresh token when an update omits it", async () => {
+    await upsertGooglePhotosConnection({
+      userId,
+      accessToken: "access-1",
+      refreshToken: "refresh-original",
+      scopes: ["scope-a"],
+    });
+
+    // Re-grant without a refresh token (Google omits it on subsequent grants).
+    await upsertGooglePhotosConnection({
+      userId,
+      accessToken: "access-2",
+      scopes: ["scope-a", "scope-b"],
+    });
+
+    const view = await getGooglePhotosConnection(userId);
+    expect(view!.accessToken).toBe("access-2");
+    expect(view!.refreshToken).toBe("refresh-original");
+    expect(view!.scopes).toEqual(["scope-a", "scope-b"]);
+  });
+
+  it("updates the access token and refresh timestamp on refresh", async () => {
+    await upsertGooglePhotosConnection({
+      userId,
+      accessToken: "old",
+      refreshToken: "r",
+      scopes: ["s"],
+    });
+
+    const newExpiry = new Date("2031-06-01T00:00:00Z");
+    await updateGooglePhotosAccessToken(userId, "new-access", newExpiry);
+
+    const view = await getGooglePhotosConnection(userId);
+    expect(view!.accessToken).toBe("new-access");
+    expect(view!.refreshToken).toBe("r");
+    expect(view!.expiresAt?.toISOString()).toBe(newExpiry.toISOString());
+    expect(view!.lastRefreshAt).toBeInstanceOf(Date);
+  });
+
+  it("marks a connection as errored", async () => {
+    await upsertGooglePhotosConnection({
+      userId,
+      accessToken: "a",
+      refreshToken: "r",
+      scopes: ["s"],
+    });
+    await markGooglePhotosConnectionError(userId, "refresh token revoked");
+
+    const view = await getGooglePhotosConnection(userId);
+    expect(view!.status).toBe("error");
+    expect(view!.lastError).toBe("refresh token revoked");
+  });
+
+  it("deletes a connection and reports whether a row was removed", async () => {
+    expect(await deleteGooglePhotosConnection(userId)).toBe(false);
+
+    await upsertGooglePhotosConnection({
+      userId,
+      accessToken: "a",
+      refreshToken: "r",
+      scopes: ["s"],
+    });
+    expect(await deleteGooglePhotosConnection(userId)).toBe(true);
+    expect(await getGooglePhotosConnection(userId)).toBeNull();
+  });
+});

--- a/apps/vionto/lib/server/__tests__/google-photos-crypto.test.ts
+++ b/apps/vionto/lib/server/__tests__/google-photos-crypto.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetEncryptionKeyCache,
+  decryptToken,
+  encryptToken,
+  getEncryptionKey,
+  safeEqual,
+} from "../google-photos/crypto";
+
+// 32-byte key as 64 hex chars.
+const HEX_KEY = "0".repeat(64);
+// 32-byte key as base64 (32 bytes of 0x01).
+const BASE64_KEY = Buffer.alloc(32, 1).toString("base64");
+
+describe("google-photos token crypto", () => {
+  const originalKey = process.env.VIONTO_TOKEN_ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    process.env.VIONTO_TOKEN_ENCRYPTION_KEY = HEX_KEY;
+    __resetEncryptionKeyCache();
+  });
+
+  afterEach(() => {
+    process.env.VIONTO_TOKEN_ENCRYPTION_KEY = originalKey;
+    __resetEncryptionKeyCache();
+  });
+
+  it("round-trips a token through encrypt → decrypt", () => {
+    const secret = "ya29.a0AfH6SMexample-access-token";
+    const encrypted = encryptToken(secret);
+    expect(encrypted).not.toContain(secret);
+    expect(decryptToken(encrypted)).toBe(secret);
+  });
+
+  it("produces a different ciphertext each time (random IV)", () => {
+    const secret = "refresh-token-value";
+    expect(encryptToken(secret)).not.toBe(encryptToken(secret));
+  });
+
+  it("round-trips unicode and empty strings", () => {
+    for (const value of ["", "日本語 🎉 café", "a".repeat(4096)]) {
+      expect(decryptToken(encryptToken(value))).toBe(value);
+    }
+  });
+
+  it("accepts a base64-encoded 32-byte key", () => {
+    process.env.VIONTO_TOKEN_ENCRYPTION_KEY = BASE64_KEY;
+    __resetEncryptionKeyCache();
+    expect(getEncryptionKey().length).toBe(32);
+    const enc = encryptToken("hello");
+    expect(decryptToken(enc)).toBe("hello");
+  });
+
+  it("throws when the key is missing", () => {
+    delete process.env.VIONTO_TOKEN_ENCRYPTION_KEY;
+    __resetEncryptionKeyCache();
+    expect(() => getEncryptionKey()).toThrow(/not set/i);
+  });
+
+  it("throws when the key is the wrong length", () => {
+    process.env.VIONTO_TOKEN_ENCRYPTION_KEY = "tooshort";
+    __resetEncryptionKeyCache();
+    expect(() => getEncryptionKey()).toThrow(/32 bytes/i);
+  });
+
+  it("detects tampering via the GCM auth tag", () => {
+    const encrypted = encryptToken("sensitive");
+    const [iv, authTag, ciphertext] = encrypted.split(".");
+    // Flip a byte in the ciphertext.
+    const buf = Buffer.from(ciphertext, "base64url");
+    buf[0] ^= 0xff;
+    const tampered = [iv, authTag, buf.toString("base64url")].join(".");
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it("rejects malformed payloads", () => {
+    expect(() => decryptToken("not-a-valid-payload")).toThrow(/malformed/i);
+    expect(() => decryptToken("a.b")).toThrow(/malformed/i);
+  });
+
+  it("safeEqual compares strings correctly", () => {
+    expect(safeEqual("abc", "abc")).toBe(true);
+    expect(safeEqual("abc", "abd")).toBe(false);
+    expect(safeEqual("abc", "abcd")).toBe(false);
+  });
+});

--- a/apps/vionto/lib/server/google-photos/connection.ts
+++ b/apps/vionto/lib/server/google-photos/connection.ts
@@ -1,0 +1,187 @@
+/**
+ * Repository for a user's Google Photos authorization.
+ *
+ * Wraps the `GooglePhotosConnection` table and handles transparent
+ * encryption/decryption of the stored OAuth tokens. Higher layers (the OAuth
+ * connect/callback routes, token-refresh helper, picker/import endpoints)
+ * should go through these functions and never read the encrypted columns
+ * directly.
+ *
+ * Foundation milestone: this is the persistence layer only. The token-refresh
+ * logic, status/disconnect endpoints, and Google API calls are implemented in
+ * their own milestone issues.
+ */
+import { prisma } from "@asafarim/db";
+
+import { decryptToken, encryptToken } from "./crypto";
+
+export type GooglePhotosConnectionStatus = "active" | "revoked" | "error";
+
+/** Plaintext view of a connection, as used by the rest of the app. */
+export type GooglePhotosConnectionView = {
+  id: string;
+  userId: string;
+  googleAccountEmail: string | null;
+  googleAccountSub: string | null;
+  accessToken: string;
+  refreshToken: string | null;
+  scopes: string[];
+  expiresAt: Date | null;
+  status: GooglePhotosConnectionStatus;
+  lastError: string | null;
+  lastRefreshAt: Date | null;
+  lastImportedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** Input for creating/updating a connection (plaintext tokens). */
+export type UpsertGooglePhotosConnectionInput = {
+  userId: string;
+  accessToken: string;
+  refreshToken?: string | null;
+  scopes: string[];
+  expiresAt?: Date | null;
+  googleAccountEmail?: string | null;
+  googleAccountSub?: string | null;
+  status?: GooglePhotosConnectionStatus;
+};
+
+type ConnectionRow = {
+  id: string;
+  userId: string;
+  googleAccountEmail: string | null;
+  googleAccountSub: string | null;
+  accessTokenEnc: string;
+  refreshTokenEnc: string | null;
+  scopes: string[];
+  expiresAt: Date | null;
+  status: string;
+  lastError: string | null;
+  lastRefreshAt: Date | null;
+  lastImportedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function toView(row: ConnectionRow): GooglePhotosConnectionView {
+  return {
+    id: row.id,
+    userId: row.userId,
+    googleAccountEmail: row.googleAccountEmail,
+    googleAccountSub: row.googleAccountSub,
+    accessToken: decryptToken(row.accessTokenEnc),
+    refreshToken: row.refreshTokenEnc ? decryptToken(row.refreshTokenEnc) : null,
+    scopes: row.scopes,
+    expiresAt: row.expiresAt,
+    status: row.status as GooglePhotosConnectionStatus,
+    lastError: row.lastError,
+    lastRefreshAt: row.lastRefreshAt,
+    lastImportedAt: row.lastImportedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** Fetch and decrypt the caller's connection, or `null` if none exists. */
+export async function getGooglePhotosConnection(
+  userId: string,
+): Promise<GooglePhotosConnectionView | null> {
+  const row = await prisma.googlePhotosConnection.findUnique({
+    where: { userId },
+  });
+  return row ? toView(row as ConnectionRow) : null;
+}
+
+/**
+ * Create or update the caller's connection, encrypting tokens before storage.
+ * A missing `refreshToken` leaves any previously stored refresh token intact
+ * (Google only returns a refresh token on the first/consent grant).
+ */
+export async function upsertGooglePhotosConnection(
+  input: UpsertGooglePhotosConnectionInput,
+): Promise<GooglePhotosConnectionView> {
+  const accessTokenEnc = encryptToken(input.accessToken);
+  const refreshTokenEnc =
+    input.refreshToken != null ? encryptToken(input.refreshToken) : undefined;
+
+  const status = input.status ?? "active";
+
+  const row = await prisma.googlePhotosConnection.upsert({
+    where: { userId: input.userId },
+    create: {
+      userId: input.userId,
+      accessTokenEnc,
+      // On create, store whatever refresh token we have (may be null).
+      refreshTokenEnc: refreshTokenEnc ?? null,
+      scopes: input.scopes,
+      expiresAt: input.expiresAt ?? null,
+      googleAccountEmail: input.googleAccountEmail ?? null,
+      googleAccountSub: input.googleAccountSub ?? null,
+      status,
+      lastError: null,
+    },
+    update: {
+      accessTokenEnc,
+      // Only overwrite the refresh token when a new one is provided.
+      ...(refreshTokenEnc !== undefined ? { refreshTokenEnc } : {}),
+      scopes: input.scopes,
+      expiresAt: input.expiresAt ?? null,
+      ...(input.googleAccountEmail !== undefined
+        ? { googleAccountEmail: input.googleAccountEmail }
+        : {}),
+      ...(input.googleAccountSub !== undefined
+        ? { googleAccountSub: input.googleAccountSub }
+        : {}),
+      status,
+      lastError: null,
+    },
+  });
+
+  return toView(row as ConnectionRow);
+}
+
+/**
+ * Persist a refreshed access token (and its new expiry) without touching the
+ * refresh token or other fields. Marks the connection active.
+ */
+export async function updateGooglePhotosAccessToken(
+  userId: string,
+  accessToken: string,
+  expiresAt: Date | null,
+): Promise<void> {
+  await prisma.googlePhotosConnection.update({
+    where: { userId },
+    data: {
+      accessTokenEnc: encryptToken(accessToken),
+      expiresAt,
+      status: "active",
+      lastError: null,
+      lastRefreshAt: new Date(),
+    },
+  });
+}
+
+/** Flag a connection as errored (e.g. refresh failed, scope revoked). */
+export async function markGooglePhotosConnectionError(
+  userId: string,
+  error: string,
+): Promise<void> {
+  await prisma.googlePhotosConnection.update({
+    where: { userId },
+    data: { status: "error", lastError: error.slice(0, 2000) },
+  });
+}
+
+/**
+ * Remove the caller's connection entirely (called on disconnect and on
+ * account deletion). Returns true if a row was deleted.
+ */
+export async function deleteGooglePhotosConnection(
+  userId: string,
+): Promise<boolean> {
+  const result = await prisma.googlePhotosConnection.deleteMany({
+    where: { userId },
+  });
+  return result.count > 0;
+}

--- a/apps/vionto/lib/server/google-photos/crypto.ts
+++ b/apps/vionto/lib/server/google-photos/crypto.ts
@@ -1,0 +1,114 @@
+/**
+ * Token encryption for the Google Photos integration.
+ *
+ * OAuth access/refresh tokens are sensitive credentials and must never be
+ * stored in plaintext. We encrypt them at rest with AES-256-GCM (authenticated
+ * encryption — tampering is detected on decrypt).
+ *
+ * Key: `VIONTO_TOKEN_ENCRYPTION_KEY` — a 32-byte key provided as either
+ *   - 64 hex characters, or
+ *   - base64 / base64url that decodes to 32 bytes.
+ *
+ * Generate one with:  `openssl rand -hex 32`
+ *
+ * Encrypted payload format (all parts base64url, dot-separated):
+ *   <iv>.<authTag>.<ciphertext>
+ */
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12; // 96-bit nonce — recommended for GCM
+const KEY_BYTES = 32; // AES-256
+const AUTH_TAG_BYTES = 16;
+
+let cachedKey: Buffer | null = null;
+
+/** Resolve and validate the 32-byte encryption key from the environment. */
+export function getEncryptionKey(): Buffer {
+  if (cachedKey) return cachedKey;
+
+  const raw = process.env.VIONTO_TOKEN_ENCRYPTION_KEY;
+  if (!raw || raw.trim().length === 0) {
+    throw new Error(
+      "VIONTO_TOKEN_ENCRYPTION_KEY is not set. Generate one with `openssl rand -hex 32`.",
+    );
+  }
+
+  const trimmed = raw.trim();
+  let key: Buffer;
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    key = Buffer.from(trimmed, "hex");
+  } else {
+    // Accept base64 or base64url.
+    key = Buffer.from(trimmed, "base64");
+  }
+
+  if (key.length !== KEY_BYTES) {
+    throw new Error(
+      `VIONTO_TOKEN_ENCRYPTION_KEY must decode to ${KEY_BYTES} bytes (got ${key.length}). ` +
+        "Provide 64 hex chars or a base64-encoded 32-byte key.",
+    );
+  }
+
+  cachedKey = key;
+  return key;
+}
+
+/** Reset the cached key — used by tests that mutate the env. */
+export function __resetEncryptionKeyCache(): void {
+  cachedKey = null;
+}
+
+/** Encrypt a UTF-8 string. Returns `iv.authTag.ciphertext` (base64url parts). */
+export function encryptToken(plaintext: string): string {
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    iv.toString("base64url"),
+    authTag.toString("base64url"),
+    ciphertext.toString("base64url"),
+  ].join(".");
+}
+
+/** Decrypt a payload produced by {@link encryptToken}. Throws on tampering. */
+export function decryptToken(payload: string): string {
+  const key = getEncryptionKey();
+  const parts = payload.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Malformed encrypted token payload");
+  }
+
+  const iv = Buffer.from(parts[0], "base64url");
+  const authTag = Buffer.from(parts[1], "base64url");
+  const ciphertext = Buffer.from(parts[2], "base64url");
+
+  if (iv.length !== IV_BYTES || authTag.length !== AUTH_TAG_BYTES) {
+    throw new Error("Malformed encrypted token payload");
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+/** Constant-time string comparison (e.g. for OAuth `state` validation). */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}

--- a/packages/db/prisma/migrations/20260531120000_add_google_photos_connection/migration.sql
+++ b/packages/db/prisma/migrations/20260531120000_add_google_photos_connection/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "GooglePhotosConnection" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "googleAccountEmail" TEXT,
+    "googleAccountSub" TEXT,
+    "accessTokenEnc" TEXT NOT NULL,
+    "refreshTokenEnc" TEXT,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "expiresAt" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "lastError" TEXT,
+    "lastRefreshAt" TIMESTAMP(3),
+    "lastImportedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GooglePhotosConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GooglePhotosConnection_userId_key" ON "GooglePhotosConnection"("userId");
+
+-- CreateIndex
+CREATE INDEX "GooglePhotosConnection_userId_idx" ON "GooglePhotosConnection"("userId");
+
+-- CreateIndex
+CREATE INDEX "GooglePhotosConnection_status_idx" ON "GooglePhotosConnection"("status");
+
+-- AddForeignKey
+ALTER TABLE "GooglePhotosConnection" ADD CONSTRAINT "GooglePhotosConnection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -84,11 +84,14 @@ model User {
   viontoSharesSent     ViontoProjectShare[] @relation("ViontoSharesSent")
   viontoSharesReceived ViontoProjectShare[] @relation("ViontoSharesReceived")
 
+  // Vionto — Google Photos import integration (incremental OAuth, separate from login identity)
+  googlePhotosConnection GooglePhotosConnection?
+
   // Generic user locations (home, work, etc.) - reusable across all apps
   locations UserLocation[]
 
   // Marketing + Content engine
-  marketingCampaigns        MarketingCampaign[]
+  marketingCampaigns         MarketingCampaign[]
   marketingPerformanceLogged MarketingPerformanceEntry[] @relation("MarketingEntryLoggedBy")
 
   createdAt DateTime @default(now())
@@ -1140,20 +1143,20 @@ model EduTutorVerification {
 // `readAt` is stamped when the *other* party reads the message, powering
 // unread badges on both the admin panel and the tutor's verification page.
 model EduVerificationMessage {
-  id         String    @id @default(cuid())
-  tutorId    String
-  senderId   String
-  senderRole String // ADMIN | TUTOR
-  body       String    @db.Text
+  id          String    @id @default(cuid())
+  tutorId     String
+  senderId    String
+  senderRole  String // ADMIN | TUTOR
+  body        String    @db.Text
   // Optional attachments: array of { key, mime, filename, sizeBytes }. Keys are
   // storage object keys scoped to the uploader; URLs are signed on read because
   // the bucket is private.
   attachments Json?
   // Emoji reactions: { [emoji]: userId[] } — emoji keys are restricted to the
   // supported set (thumbsup, thumbsdown, check, question, eyes, tada).
-  reactions  Json?
-  readAt     DateTime?
-  createdAt  DateTime  @default(now())
+  reactions   Json?
+  readAt      DateTime?
+  createdAt   DateTime  @default(now())
 
   tutor  User @relation("EduVerificationMessageTutor", fields: [tutorId], references: [id], onDelete: Cascade)
   sender User @relation("EduVerificationMessageSender", fields: [senderId], references: [id], onDelete: Cascade)
@@ -1798,14 +1801,14 @@ model MarketingCampaign {
   /// null = shared demo data; otherwise scoped to the creating user.
   ownerId String?
 
-  name      String
-  channel   String // seo, email, paid, social, partner
-  status    String @default("scheduled") // live, scheduled, paused, ended
-  owner     String // display name of the campaign owner
-  budgetCents Int  @default(0)
-  startedAt DateTime
+  name           String
+  channel        String // seo, email, paid, social, partner
+  status         String    @default("scheduled") // live, scheduled, paused, ended
+  owner          String // display name of the campaign owner
+  budgetCents    Int       @default(0)
+  startedAt      DateTime
   /// Optional planned end date — enables budget-pacing projections (M3).
-  endsAt    DateTime?
+  endsAt         DateTime?
   /// Optional target cost-per-acquisition in cents — drives the CPA-over flag (M3).
   cpaTargetCents Int?
 
@@ -1850,12 +1853,55 @@ model MarketingPerformanceEntry {
   loggedById String?
   loggedAt   DateTime @default(now())
 
-  campaign       MarketingCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  loggedByUser   User?             @relation("MarketingEntryLoggedBy", fields: [loggedById], references: [id], onDelete: SetNull)
+  campaign     MarketingCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  loggedByUser User?             @relation("MarketingEntryLoggedBy", fields: [loggedById], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
 
   @@index([campaignId])
   @@index([campaignId, weekOf])
   @@index([weekOf])
+}
+
+// ─── Vionto — Google Photos Import ─────────────────────────────
+//
+// Persists a user's authorization to import photos from their Google
+// Photos library and shared albums. This is an *incremental OAuth*
+// grant that is intentionally decoupled from the user's login identity:
+// a user who signed in with email/password (or email-code) can still
+// connect a Google account purely for photo import.
+//
+// OAuth tokens are stored encrypted at rest (AES-256-GCM). The plaintext
+// access/refresh tokens never touch the database — see
+// apps/vionto/lib/server/google-photos/crypto.ts.
+
+model GooglePhotosConnection {
+  id     String @id @default(cuid())
+  userId String @unique
+
+  // Google account that granted access (may differ from the Vionto login email).
+  googleAccountEmail String?
+  googleAccountSub   String? // Google "sub" — stable account identifier
+
+  // Encrypted OAuth tokens. Format: iv.authTag.ciphertext (all base64url).
+  accessTokenEnc  String  @db.Text
+  refreshTokenEnc String? @db.Text
+
+  // Granted OAuth scopes and access-token expiry.
+  scopes    String[]  @default([])
+  expiresAt DateTime?
+
+  // Connection lifecycle.
+  status         String    @default("active") // active | revoked | error
+  lastError      String?   @db.Text
+  lastRefreshAt  DateTime?
+  lastImportedAt DateTime?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([status])
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -60,6 +60,7 @@ export type {
   ViontoRenderJob,
   ViontoExport,
   ViontoAuditEvent,
+  GooglePhotosConnection,
   MarketingCampaign,
   MarketingPerformanceEntry,
 } from "@prisma/client";


### PR DESCRIPTION
@
## Summary

Foundation slice of the **[Vionto: Google Photos Import](https://github.com/AliSafari-IT/asafarim-digital/milestone/2)** milestone. Lands the spike decision, configuration, and data model so the OAuth/connect, picker, and import issues can build on a stable base.

Closes #144 · Closes #145 · Closes #146

## What changed

### #144 — Spike / decision record
- New design doc: `apps/vionto/docs/google-photos-import.md`.
- Key decisions:
  - Use the **Google Photos Picker API** (the Library API `readonly` scope was restricted to app-created data on 2025-03-31). Scope: `photospicker.mediaitems.readonly` (non-sensitive → lighter verification).
  - **Incremental OAuth, decoupled from login** — email/password and email-code users can still connect a Google account purely for import.
  - **Shared-album URL import is gated** behind a restricted sharing scope + Google security assessment; Phase 1 falls back to the Picker. Issues #150/#154 carry this caveat.

### #145 — Configuration
- Documented `GOOGLE_PHOTOS_CLIENT_ID/SECRET`, `GOOGLE_PHOTOS_REDIRECT_URI`, `GOOGLE_PHOTOS_SCOPES`, and `VIONTO_TOKEN_ENCRYPTION_KEY` in the root `.env.example`, `apps/vionto/.env.example`, and `apps/vionto/README.md`.
- Google Cloud Console setup steps captured in the doc (consent screen, API enablement, redirect URIs, verification-early note).

### #146 — Data model
- New `GooglePhotosConnection` Prisma model (one row/user, cascade-delete with User) + migration `20260531120000_add_google_photos_connection`.
- **AES-256-GCM** token encryption helper (`lib/server/google-photos/crypto.ts`) — OAuth tokens are never stored in plaintext; tampering is detected on decrypt.
- Connection repository (`lib/server/google-photos/connection.ts`) — the only layer that touches the encrypted columns; exposes upsert / refresh / status / delete over a decrypted view. Refresh-token preservation on re-grant is handled.

## Testing
- `vitest run` for the two new suites — **15 passing** (crypto round-trip, key validation, GCM tamper detection; repository encryption-at-rest, refresh-token preservation, delete semantics).
- `tsc --noEmit` passes for both `@asafarim/db` and `vionto`.
- `prisma validate` passes; client regenerated.

⚠️ The repo has **12 pre-existing test failures** (snapshot drift in `story-generation`/`srt` narration prompts) unrelated to this PR — verified they reproduce on a clean tree with these changes stashed.

## Notes
- The migration is committed but **not applied** to the shared database here — run `pnpm --filter @asafarim/db db:migrate:deploy` (or `db:migrate`) during deploy.
- Generate a `VIONTO_TOKEN_ENCRYPTION_KEY` per environment with `openssl rand -hex 32` before the connect flow (#147) ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

Refs #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Photos import capability enabling users to securely import photos from their Google Photos accounts with OAuth integration.

* **Documentation**
  * Updated environment configuration documentation and added setup guides for Google Photos integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->